### PR TITLE
add linked kvs

### DIFF
--- a/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boosted/list.json
+++ b/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boosted/list.json
@@ -1,1 +1,2137 @@
-{"blocklist":{"abaddon_frostmourne":{"curse_duration":1,"slow_duration":1},"abyssal_underlord_atrophy_aura":{"pit_duration":1},"abyssal_underlord_dark_portal":{"duration":1},"abyssal_underlord_pit_of_malice":{"ensnare_duration":1,"pit_damage":1},"alchemist_chemical_rage":{"bonus_health":1,"bonus_mana_regen":1,"scepter_gold_damage":1},"alchemist_unstable_concoction":{"brew_time":1,"max_damage":1,"max_stun":1,"min_damage":1,"min_stun":1,"radius":1},"alchemist_unstable_concoction_throw":{"brew_time":1,"max_damage":1,"min_damage":1,"vision_range":1},"all":{"AbilityCastPoint":1,"AbilityCastRange":1,"AbilityCharges":1,"AbilityCooldown":1,"AbilityManaCost":1,"CalculateSpellDamageTooltip":1,"DamageTypeTooltip":1,"LinkedSpecialBonus":1,"LinkedSpecialBonusField":1,"LinkedSpecialBonusOperation":1,"RequiresScepter":1,"RequiresShard":1,"ability_capture":1,"ability_lamp_use":1,"ability_pluck_famango":1,"abyssal_underlord_portal_warp":1,"ad_linked_abilities":1,"bonus_cdr":1,"cannot_be_dispelled":1,"cooldown_reduction":1,"crit_chance":1,"dispel":1,"familiar_armor":1,"familiar_attack_damage":1,"familiar_hp":1,"familiar_speed":1,"generic_hidden":1,"kunkka_x_marks_the_spot":1,"levelkey":1,"lycan_summon_wolves":1,"max_invoked_spells":1,"pierce_immunity":1,"pierces_immunity":1,"pierces_magic_immunity":1,"respawn":1,"special_bonus_attributes":1,"tusk_frozen_sigil":1,"twin_gate_portal_warp":1,"undispellable":1,"var_type":1,"venomancer_plague_ward":1,"visage_stone_form_self_cast":1},"ancient_apparition_cold_feet":{"AbilityCharges":1,"AbilityDuration":1,"area_of_effect":1},"ancient_apparition_ice_vortex":{"drag_speed":1},"antimage_blink":{"min_blink_range":1},"antimage_counterspell":{"min_blink_range":1},"antimage_mana_break":{"silence_chance":1,"silence_duration":1},"arc_warden_tempest_double":{"tempest_double_cooldown_reduction":1},"axe_counter_helix":{"cooldown":1,"shard_bonus_chance":1,"trigger_chance":1},"axe_culling_blade":{"charge_speed":1},"bane_nightmare":{"AbilityDuration":1,"animation_rate":1,"nightmare_invuln_time":1},"batrider_flamebreak":{"collision_radius":1,"knockback_height":1},"batrider_flaming_lasso":{"allied_cooldown":1,"grab_radius":1},"beastmaster_drums_of_slom":{"AbilityDuration":1,"movespeed_slow":1},"beastmaster_inner_beast":{"scepter_cooldown":1,"scepter_duration":1,"scepter_manacost":1,"scepter_multiplier":1,"scepter_radius":1},"beastmaster_wild_axes":{"range":1,"scepter_cooldown":1},"bounty_hunter_shuriken_toss":{"cast_range":1,"scepter_cooldown":1},"bounty_hunter_track":{"bonus_gold_radius":1,"gold_steal":1},"bounty_hunter_wind_walk":{"shard_damage_reduction_pct":1},"brewmaster_drunken_brawler":{"slow_duration":1},"bristleback_bristleback":{"back_angle":1,"side_angle":1},"centaur_double_edge":{"scepter_range":1},"centaur_stampede":{"base_damage":1},"chaos_knight_chaos_bolt":{"fake_bolt_distance":1},"chaos_knight_chaos_strike":{"chance":1},"chaos_knight_phantasm":{"magic_resistance":1,"outgoing_damage":1,"vision_radius":1},"chaos_knight_reality_rift":{"cast_range":1},"chen_divine_favor":{"teleport_delay":1},"chen_hand_of_god":{"ancient_creeps_scepter":1,"does_purge":1},"chen_holy_persuasion":{"AbilityCharges":1,"is_martyr":1},"crystal_maiden_freezing_field":{"can_move":1},"crystal_maiden_frostbite":{"tick_interval":1},"dark_seer_ion_shell":{"tick_interval":1},"dark_seer_surge":{"AbilityCharges":1},"dark_seer_wall_of_replica":{"replica_damage_incoming":1,"replica_damage_outgoing":1,"replica_scale":1},"dark_willow_bedlam":{"attack_targets":1},"dark_willow_bramble_maze":{"initial_creation_delay":1,"latch_creation_delay":1,"latch_creation_interval":1,"latch_range":1,"placement_count":1,"placement_range":1},"dark_willow_shadow_realm":{"duration":1,"scepter_radius":1},"dark_willow_terrorize":{"starting_height":1,"telegraph_to_enemies":1},"dawnbreaker_fire_wreath":{"animation_rate":1,"total_attacks":1,"turn_rate":1},"dawnbreaker_luminosity":{"attack_count":1},"dazzle_poison_touch":{"bonus_damage":1},"dazzle_shallow_grave":{"fx_halo_height":1},"death_prophet_carrion_swarm":{"end_radius":1,"start_radius":1},"death_prophet_exorcism":{"average_damage":1,"ghost_spawn_rate":1,"give_up_distance":1,"max_distance":1,"radius":1,"scepter_movespeed_slow":1,"scepter_spirit_life_duration":1,"spirit_speed":1},"death_prophet_silence":{"projectile_speed":1},"death_prophet_spirit_siphon":{"AbilityChargeRestoreTime":1,"movement_steal":1},"disruptor_glimpse":{"backtrack_time":1,"cast_range":1,"silence_duration":1},"disruptor_kinetic_field":{"damage_per_second":1},"doom_bringer_devour":{"armor":1,"bonus_gold":1,"creep_level":1,"hero_ability_steal_time":1},"doom_bringer_doom":{"deniable_pct":1,"scepter_cooldown":1},"doom_bringer_scorched_earth":{"damage_per_hero":1},"dragon_knight_elder_dragon_form":{"bonus_attack_damage":1,"magic_resistance":1,"model_scale":1},"dragon_knight_fireball":{"burn_interval":1},"drow_ranger_multishot":{"arrow_count_per_wave":1,"bypass_block":1,"wave_count":1},"earth_spirit_boulder_smash":{"rock_search_aoe":1},"earth_spirit_geomagnetic_grip":{"total_pull_distance":1},"earth_spirit_rolling_boulder":{"damage_str":1},"earthshaker_enchant_totem":{"scepter_acceleration_horizontal":1,"scepter_acceleration_z":1,"scepter_cleave_ending_width":1,"scepter_cleave_starting_width":1,"scepter_height":1,"scepter_height_arcbuffer":1},"earthshaker_fissure":{"fissure_radius":1,"fissure_range":1},"elder_titan_ancestral_spirit":{"move_pct_cap":1,"speed":1},"elder_titan_earth_splitter":{"speed":1,"total_steps":1,"vision_duration":1,"vision_interval":1,"vision_step":1,"vision_width":1},"elder_titan_echo_stomp":{"animation_rate":1,"cast_time":1},"ember_spirit_activate_fire_remnant":{"charge_restore_time":1,"damage":1,"max_charges":1,"scepter_mana_cost":1,"shard_remnant_speed_pct":1,"speed_multiplier":1},"ember_spirit_fire_remnant":{"AbilityChargeRestoreTime":1,"duration":1},"ember_spirit_flame_guard":{"AbilityChargeRestoreTime":1,"blind_pct":1},"ember_spirit_searing_chains":{"radius_scepter":1},"ember_spirit_sleight_of_fist":{"AbilityCharges":1,"creep_damage_penalty":1},"enchantress_bunny_hop":{"hop_duration":1,"hop_height":1},"enchantress_natures_attendants":{"heal_interval":1,"movespeed":1,"shard_permanent_wisp_count":1},"enigma_black_hole":{"animation_rate":1,"duration":1,"tick_rate":1,"vision_radius":1},"enigma_midnight_pulse":{"duration":1},"enraged_wildkin_tornado":{"AbilityChannelTime":1},"faceless_void_chronosphere":{"bonus_attack_speed":1,"vision_radius":1},"furion_force_of_nature":{"treant_large_damage_bonus":1,"treant_large_hp_bonus":1},"furion_sprout":{"sprout_damage_inteval":1,"vision_range":1},"generic_hidden":{"duration":1},"grimstroke_dark_artistry":{"abilitycastrange":1,"end_radius":1,"start_radius":1},"grimstroke_ink_creature":{"hero_attack_multiplier":1,"infection_search_radius":1,"latched_unit_offset":1,"latched_unit_offset_short":1,"return_projectile_speed":1,"spawn_time":1,"tick_interval":1},"grimstroke_soul_chain":{"chain_break_distance":1,"creep_duration_pct":1,"leash_limit_multiplier":1,"leash_radius_buffer":1},"grimstroke_spirit_walk":{"tick_rate":1},"gyrocopter_call_down":{"damage_second_scepter":1,"range_scepter":1},"gyrocopter_flak_cannon":{"fire_rate":1,"projectile_speed":1,"scepter_radius":1},"gyrocopter_homing_missile":{"attack_speed_bonus_pct":1},"gyrocopter_rocket_barrage":{"rockets_per_second":1},"hoodwink_acorn_shot":{"bounce_delay":1},"hoodwink_bushwhack":{"animation_rate":1,"visual_height":1},"hoodwink_decoy":{"projectile_speed":1},"invoker_chaos_meteor":{"end_vision_duration":1,"meteor_count":1,"vision_distance":1},"invoker_deafening_blast":{"end_vision_duration":1,"radius_end":1,"radius_start":1},"invoker_forge_spirit":{"armor_per_attack":1,"extra_spirit_count_exort":1,"extra_spirit_count_quas":1},"invoker_ice_wall":{"num_wall_elements":1,"wall_element_radius":1,"wall_element_spacing":1,"wall_place_distance":1},"invoker_sun_strike":{"delay":1,"vision_distance":1,"vision_duration":1},"invoker_tornado":{"end_vision_duration":1,"quas_damage":1,"vision_distance":1},"item_aegis":{"disappear_time_turbo":1},"item_aeon_disk":{"max_level":1},"item_afterburner":{"tick_rate":1},"item_armlet":{"unholy_bonus_attack_speed":1},"item_black_king_bar":{"max_level":1},"item_blade_mail":{"bonus_intellect":1},"item_blink":{"blink_range":1,"blink_range_clamp":1},"item_bottle":{"max_charges":1},"item_heart":{"bonus_strength":1},"item_mirror_shield":{"block_cooldown":1},"item_moon_shard":{"consumed_bonus":1},"item_obsidian_pauldrons":{"tick_rate":1},"item_octarine_core":{"bonus_cooldown":1},"item_orb_of_contagion":{"tick_rate":1},"item_power_treads":{"bonus_damage":1},"item_quickening_charm":{"bonus_cooldown":1},"item_radiance":{"upgrade_day_vision":1},"item_ruthless_dagger":{"tick_rate":1},"item_spell_prism":{"bonus_cooldown":1},"item_tpscroll":{"AbilityChannelTime":1,"minimun_distance":1,"vision_radius":1},"item_travel_boots_2":{"tp_channel_time":1},"item_wand_of_the_brine":{"damage_reduction":1},"jakiro_dual_breath":{"end_radius":1,"fire_delay":1,"range":1,"speed":1,"speed_fire":1,"start_radius":1},"jakiro_liquid_ice":{"stun_duration":1},"jakiro_macropyre":{"burn_interval":1,"cast_range":1},"juggernaut_blade_dance":{"blade_dance_lifesteal":1},"juggernaut_blade_fury":{"blade_fury_damage_tick":1,"duration":1},"keeper_of_the_light_blinding_light":{"AbilityCharges":1},"keeper_of_the_light_chakra_magic":{"duration":1,"mana_leak_pct":1},"keeper_of_the_light_illuminate":{"channel_vision_duration":1,"channel_vision_interval":1,"channel_vision_radius":1,"channel_vision_step":1,"max_channel_time":1,"vision_duration":1},"keeper_of_the_light_spirit_form_illuminate":{"channel_vision_duration":1,"channel_vision_interval":1,"channel_vision_radius":1,"channel_vision_step":1,"max_channel_time":1,"vision_duration":1},"kunkka_tidebringer":{"cleave_ending_width":1,"cleave_starting_width":1},"legion_commander_duel":{"victory_range":1},"legion_commander_moment_of_courage":{"buff_duration":1,"trigger_chance":1},"leshrac_diabolic_edict":{"abilityduration":1,"shard_max_count":1,"tower_bonus":1},"leshrac_lightning_storm":{"interval_scepter":1,"radius_scepter":1},"leshrac_split_earth":{"shard_max_count":1},"lich_chain_frost":{"vision_radius":1},"lich_frost_shield":{"damage_reduction":1,"duration":1},"life_stealer_infest":{"damage_increase_pct":1,"damage_threshold":1},"life_stealer_rage":{"duration":1},"lina_dragon_slave":{"AbilityDuration":1,"dragon_slave_distance":1,"dragon_slave_speed":1},"lina_fiery_soul":{"fiery_soul_max_stacks":1},"lina_flame_cloak":{"visualzdelta":1},"lina_laguna_blade":{"cast_range_scepter":1,"damage_delay":1,"scepter_width":1},"lion_finger_of_death":{"damage_delay":1},"lion_impale":{"length_buffer":1,"speed":1},"lion_mana_drain":{"tick_interval":1},"lone_druid_savage_roar":{"only_affects_player_units":1},"lone_druid_spirit_bear":{"bear_armor":1,"bear_hp":1,"bear_regen_tooltip":1,"cooldown_scepter":1},"luna_lucent_beam":{"search_radius":1},"lycan_summon_wolves_invisibility":{"fade_time":1},"magnataur_empower":{"cleave_ending_width":1,"cleave_starting_width":1},"magnataur_horn_toss":{"destination_offset":1,"pull_angle":1,"pull_offset":1},"magnataur_reverse_polarity":{"pull_duration":1},"magnataur_skewer":{"skewer_cooldown":1,"skewer_manacost":1,"tool_attack_slow":1},"marci_companion_run":{"impact_position_offset":1,"max_acceleration":1,"max_lob_travel_time":1,"min_acceleration":1,"min_height_above_highest":1,"min_height_above_lowest":1,"min_lob_travel_time":1,"move_speed":1,"scepter_armor":1,"scepter_heal":1,"target_abort_distance":1,"vector_preview_radius":1},"marci_grapple":{"pull_angle":1,"pull_offset":1},"marci_guardian":{"bonus_attack_range":1},"marci_unleash":{"shard_push_length":1},"mars_arena_of_blood":{"first_warrior_angle":1,"formation_time":1,"spear_distance_from_wall":1,"warrior_count":1,"warrior_fade_max_dist":1,"warrior_fade_min_dist":1,"width":1},"mars_bulwark":{"forward_angle":1,"redirect_chance":1,"redirect_range":1,"side_angle":1,"soldier_count":1,"soldier_offset":1},"mars_gods_rebuke":{"activity_duration":1,"scepter_cooldown":1},"mars_spear":{"activity_duration":1,"knockback_distance":1,"knockback_duration":1,"shard_interval":1,"shard_trail_duration":1},"medusa_cold_blooded":{"damage":1},"medusa_mystic_snake":{"jump_delay":1,"stone_form_scepter_base":1},"meepo_poof":{"AbilityChannelTime":1},"mirana_invis":{"duration":1},"mirana_leap":{"leap_acceleration":1},"monkey_king_boundless_strike":{"soldier_spawn_duration":1},"monkey_king_tree_dance":{"perched_spot_height":1,"range":1,"top_level_height":1},"monkey_king_wukongs_command":{"cast_range_scepter":1,"duration":1,"leadership_radius_buffer":1,"outer_attack_buffer":1},"morphling_morph_agi":{"bonus_attributes":1,"castable_while_stunned":1,"morph_cooldown":1},"morphling_morph_str":{"bonus_attributes":1,"castable_while_stunned":1,"morph_cooldown":1},"morphling_waveform":{"AbilityCharges":1,"abilitycastrange":1},"muerta_the_calling":{"debug_draw":1,"rotation_direction":1,"rotation_initial":1,"show_warning":1},"naga_siren_rip_tide":{"debuff_duration":1},"naga_siren_song_of_the_siren":{"animation_rate":1,"regen_rate":1,"regen_rate_self":1,"scepter_cooldown":1},"necrolyte_death_pulse":{"projectile_speed":1},"necrolyte_death_seeker":{"projectile_multiplier":1},"necrolyte_heartstopper_aura":{"aura_radius":1},"nevermore_necromastery":{"attack_range_bonus":1,"necromastery_soul_release":1},"nevermore_shadowraze1":{"shadowraze_cooldown":1},"nevermore_shadowraze2":{"shadowraze_cooldown":1},"nevermore_shadowraze3":{"shadowraze_cooldown":1},"nyx_assassin_impale":{"length":1,"width":1},"nyx_assassin_mana_burn":{"aoe":1},"nyx_assassin_spiked_carapace":{"bonus_armor":1,"bonus_damage":1,"bonus_intellect":1},"nyx_assassin_vendetta":{"fade_time":1,"health_regen_rate_scepter":1,"mana_regen_rate_scepter":1},"obsidian_destroyer_arcane_orb":{"bounce_radius":1},"obsidian_destroyer_astral_imprisonment":{"scepter_range_bonus":1},"obsidian_destroyer_equilibrium":{"mana_capacity_duration":1,"mana_capacity_steal":1,"shard_bonus_mana":1,"shard_mana_duration":1},"obsidian_destroyer_sanity_eclipse":{"cast_range":1},"ogre_magi_bloodlust":{"modelscale":1},"ogre_magi_smash":{"projectile_speed":1},"oracle_false_promise":{"radius":1},"oracle_fortunes_end":{"scepter_bonus_radius":1,"scepter_bonus_range":1,"scepter_stun_percentage":1},"pangolier_gyroshell":{"tick_interval":1,"turn_rate_boosted":1},"pangolier_lucky_shot":{"slow":1},"pangolier_rollup":{"bounce_duration":1,"cast_time_tooltip":1,"forward_move_speed":1,"hit_radius":1,"jump_recover_time":1,"knockback_radius":1,"radius":1,"stun_duration":1,"tick_interval":1,"turn_rate":1,"turn_rate_boosted":1},"pangolier_shield_crash":{"duration":1},"pangolier_swashbuckle":{"attack_interval":1,"dash_range":1,"end_radius":1,"start_radius":1},"phantom_assassin_fan_of_knives":{"degen":1,"max_damage_initial":1,"pct_health_damage":1},"phantom_assassin_phantom_strike":{"AbilityCharges":1,"abilitycastrange":1},"phantom_assassin_stifling_dagger":{"attack_factor":1},"phantom_lancer_doppelwalk":{"illusion_1_damage_in_pct":1},"phantom_lancer_spirit_lance":{"fake_lance_distance":1},"phoenix_fire_spirits":{"attackspeed_slow":1,"damage_per_second":1,"duration":1,"radius":1,"spirit_count":1,"spirit_speed":1,"tick_interval":1},"phoenix_launch_fire_spirit":{"hp_cost_perc":1,"spirit_count":1,"spirit_duration":1},"phoenix_sun_ray":{"tick_interval":1,"turn_rate_initial":1},"primal_beast_onslaught":{"chargeup_time":1,"max_charge_time":1},"primal_beast_pulverize":{"animation_rate":1,"cast_range":1,"pierce_immunity":1},"primal_beast_rock_throw":{"bounce_travel_time":1,"fragment_impact_distance":1,"fragment_impact_radius":1},"primal_beast_trample":{"step_distance":1},"primal_beast_uproar":{"damage_max":1,"damage_min":1,"roared_bonus_attack_speed":1,"should_dispell":1},"pudge_dismember":{"abilitychanneltime":1,"animation_rate":1,"order_lock_duration":1,"pull_distance_limit":1,"pull_units_per_second":1},"pudge_meat_hook":{"hook_distance":1,"vector_target_distance":1,"vision_duration":1,"vision_radius":1},"pudge_rot":{"rot_tick":1},"pugna_decrepify":{"abilityduration":1,"bonus_movement_speed_allies":1},"pugna_life_drain":{"scepter_cooldown":1,"tick_rate":1},"pugna_nether_ward":{"mana_regen":1,"spell_damage_reduction":1},"queenofpain_scream_of_pain":{"projectile_speed":1},"queenofpain_sonic_wave":{"starting_aoe":1},"rattletrap_hookshot":{"cooldown_scepter":1},"rattletrap_overclocking":{"bonus_movement_speed":1,"buff_duration":1,"rocket_flare_cooldown":1,"rocket_flare_rockets":1},"rattletrap_power_cogs":{"bonus_armor":1,"extra_pull_buffer":1,"leash":1},"rattletrap_rocket_flare":{"AbilityCooldown":1,"damage":1},"razor_static_link":{"radius":1,"vision_duration":1,"vision_radiuss":1},"riki_backstab":{"backstab_angle":1},"riki_blink_strike":{"AbilityChargeRestoreTime":1,"abilitycastrange":1},"riki_smoke_screen":{"duration":1},"riki_tricks_of_the_trade":{"AbilityChannelTime":1,"damage_pct":1,"dispel":1,"scepter_cast_range":1,"scepter_duration":1},"rubick_telekinesis":{"fall_duration":1,"shard_teammate_throw_delay":1},"rubick_telekinesis_land":{"radius":1},"rubick_telekinesis_land_self":{"radius":1},"sandking_burrowstrike":{"burrow_anim_time":1,"burrow_speed":1,"burrow_speed_scepter":1},"sandking_epicenter":{"epicenter_pulses":1},"sandking_sand_storm":{"damage_tick_rate":1,"fade_delay":1},"shadow_demon_disruption":{"AbilityCharges":1,"illusion_bounty_base":1,"illusion_bounty_growth":1},"shadow_demon_soul_catcher":{"illusion_incoming_damage":1,"illusion_outgoing_damage":1},"shadow_shaman_ether_shock":{"end_radius":1,"start_radius":1},"shadow_shaman_mass_serpent_ward":{"scepter_range":1},"shadow_shaman_shackles":{"AbilityChannelTime":1,"tick_interval":1},"shredder_chakram":{"castpoint_scepter":1,"damage_interval":1},"shredder_chakram_2":{"castpoint_scepter":1,"damage_interval":1},"shredder_flamethrower":{"building_dmg_pct":1},"shredder_timber_chain":{"chain_radius":1},"shredder_whirling_death":{"whirling_tick":1},"silencer_glaives_of_wisdom":{"AbilityDuration":1},"silencer_last_word":{"scepter_bonus_damage":1},"skeleton_king_vampiric_aura":{"gold_bounty":1,"xp_bounty":1},"skywrath_mage_arcane_bolt":{"bolt_vision":1,"vision_duration":1},"skywrath_mage_mystic_flare":{"damage_interval":1},"skywrath_mage_shield_of_the_scion":{"stack_duration":1},"slardar_amplify_damage":{"undispellable":1},"slark_dark_pact":{"pulse_duration":1,"pulse_interval":1,"total_pulses":1},"slark_pounce":{"pounce_acceleration":1,"pounce_speed":1},"slark_shadow_dance":{"activation_delay":1,"fade_time":1,"neutral_disable":1},"snapfire_firesnap_cookie":{"jump_duration":1,"jump_height":1,"landing_gesture_duration":1,"pre_hop_duration":1,"pre_land_anim_time":1,"self_cast_delay":1,"target_heal":1},"snapfire_mortimer_kisses":{"burn_interval":1,"delay_after_last_projectile":1,"dist_change_speed":1,"max_lob_travel_time":1,"min_lob_travel_time":1,"projectile_count":1,"projectile_speed":1,"projectile_vision":1,"projectile_width":1,"turn_rate":1},"snapfire_scatterblast":{"blast_speed":1,"blast_width_end":1,"blast_width_initial":1,"point_blank_range":1},"snapfire_spit_creep":{"burn_interval":1,"dist_change_speed":1,"max_acceleration":1,"max_lob_travel_time":1,"min_acceleration":1,"min_height_above_highest":1,"min_height_above_lowest":1,"min_lob_travel_time":1,"min_range":1,"projectile_speed":1,"projectile_vision":1,"projectile_width":1,"turn_rate":1},"sniper_assassinate":{"abilitycastpoint":1,"scatter_damage_pct":1,"scatter_range":1,"scatter_width":1,"scepter_crit":1},"sniper_shrapnel":{"AbilityCharges":1},"spectre_haunt":{"attack_delay":1},"spectre_haunt_single":{"attack_delay":1},"spirit_breaker_charge_of_darkness":{"scepter_cast_point":1,"scepter_speed":1,"vision_duration":1,"vision_radius":1},"spirit_breaker_greater_bash":{"bonus_movespeed_pct":1,"movespeed_duration":1},"spirit_breaker_nether_strike":{"fade_time":1,"shard_bonus_damage":1,"shard_break_duration":1,"shard_spell_immune_duration":1},"storm_spirit_ball_lightning":{"ball_lightning_initial_mana_percentage":1,"ball_lightning_travel_cost_base":1,"ball_lightning_vision_radius":1,"blocker_duration":1},"storm_spirit_electric_vortex":{"abilityduration":1},"sven_great_cleave":{"cleave_starting_width":1},"sven_storm_bolt":{"vision_radius":1},"techies_land_mines":{"AbilityChargeRestoreTime":1,"cast_range_scepter_bonus":1,"lifetime":1},"techies_minefield_sign":{"aura_radius":1,"lifetime":1},"techies_sticky_bomb":{"acceleration":1,"duration":1,"pre_chase_time":1,"secondary_slow_duration":1,"speed":1},"templar_assassin_psionic_trap":{"movement_speed_max":1,"movement_speed_min":1,"shard_bonus_vision":1,"shard_max_silence_duration":1,"shard_min_silence_duration":1,"trap_bonus_damage":1,"trap_duration":1,"trap_max_charge_duration":1,"trap_radius":1},"templar_assassin_refraction":{"cast_while_disabled":1},"templar_assassin_trap":{"shard_bonus_max_traps":1,"trap_duration":1},"templar_assassin_trap_teleport":{"movement_speed_max":1,"movement_speed_min":1,"trap_bonus_damage":1,"trap_duration":1,"trap_max_charge_duration":1,"trap_radius":1},"terrorblade_metamorphosis":{"speed_loss":1},"terrorblade_reflection":{"illusion_outgoing_damage":1},"tidehunter_anchor_smash":{"targets_buildings":1},"tidehunter_arm_of_the_deep":{"duration_pct":1},"tinker_heat_seeking_missile":{"radius_explosion":1,"splash_pct":1},"tinker_rearm":{"AbilityChannelTime":1},"tiny_grow":{"attack_speed_reduction":1},"tiny_toss":{"AbilityCharges":1,"bonus_damage_pct":1},"tiny_tree_channel":{"abilitychanneltime":1,"bonus_damage":1,"interval":1,"range":1},"tiny_tree_grab":{"bat_increase":1,"speed_reduction":1},"treant_eyes_in_the_forest":{"overgrowth_aoe":1,"tree_respawn_seconds":1,"vision_aoe":1},"treant_leech_seed":{"projectile_speed":1},"treant_natures_grasp":{"creation_interval":1,"initial_latch_delay":1,"latch_range":1,"latch_vision":1,"vine_spawn_interval":1},"treant_natures_guise":{"shard_tree_movement_bonus_pct":1},"treant_overgrowth":{"purgable":1},"troll_warlord_battle_trance":{"scepter_duration_enemies":1},"troll_warlord_berserkers_rage":{"bonus_hp":1,"bonus_range":1},"troll_warlord_whirling_axes_melee":{"max_range":1},"tusk_ice_shards":{"shard_angle_step":1,"shard_count":1,"shard_distance":1,"shard_width":1,"turn_rate_slow":1},"tusk_snowball":{"snowball_grow_rate":1,"snowball_windup_radius":1},"tusk_walrus_punch":{"push_length":1},"undying_decay":{"str_scale_up":1},"undying_tombstone":{"tombstone_health":1},"ursa_earthshock":{"AbilityChargeRestoreTime":1,"AbilityDuration":1,"hop_duration":1,"hop_height":1},"ursa_enrage":{"cooldown_scepter":1,"damage_reduction":1,"duration":1},"ursa_fury_swipes":{"stun_duration":1},"vengefulspirit_nether_swap":{"damage_reduction":1,"scepter_charge_reduction":1,"scepter_radius":1},"venomancer_poison_nova":{"aspd_slow":1},"venomancer_venomous_gale":{"create_wards":1,"shard_ward_count":1},"viper_nethertoxin":{"projectile_speed":1},"viper_poison_attack":{"bonus_range":1},"viper_viper_strike":{"charge_restore_time":1,"max_charges":1},"visage_grave_chill":{"radius":1},"visage_gravekeepers_cloak":{"max_damage_reduction":1,"radius":1},"void_spirit_aether_remnant":{"end_radius":1,"projectile_speed":1,"pull_destination":1,"radius":1,"remnant_watch_radius":1,"start_radius":1,"think_interval":1,"watch_path_vision_radius":1},"void_spirit_astral_step":{"AbilityChargeRestoreTime":1,"AbilityCharges":1,"ability_chance_pct":1,"attack_chance_pct":1,"min_travel_distance":1},"void_spirit_dissimilate":{"destination_fx_radius":1},"void_spirit_resonant_pulse":{"return_projectile_speed":1,"speed":1},"warlock_rain_of_chaos":{"bounty_reduction_scepter":1,"hp_dmg_reduction_scepter":1,"number_of_golems_scepter":1},"weaver_geminate_attack":{"delay":1},"weaver_shukuchi":{"AbilityCharges":1},"wildcard":{"cooldown":1,"interval":1,"tooltip":1},"windrunner_focusfire":{"focusfire_fire_on_the_move":1},"windrunner_shackleshot":{"arrow_speed":1,"shackle_angle":1,"shackle_count":1},"windrunner_windrun":{"duration":1},"winter_wyvern_arctic_burn":{"tree_destruction_radius":1},"winter_wyvern_splinter_blast":{"projectile_max_time":1,"projectile_speed":1,"secondary_projectile_speed":1},"winter_wyvern_winters_curse":{"damage_amplification":1,"early_out_timer":1},"wisp_spirits":{"revolution_time":1,"spirit_amount":1,"spirit_duration":1},"wisp_tether":{"latch_distance":1,"radius":1,"self_bonus":1},"witch_doctor_death_ward":{"scepter_lifesteal":1},"witch_doctor_maledict":{"abilityduration":1,"bonus_damage_threshold":1},"witch_doctor_paralyzing_cask":{"bounce_delay":1},"witch_doctor_voodoo_restoration":{"enemy_damage_pct":1,"heal_interval":1},"zuus_cloud":{"cloud_duration":1},"zuus_heavenly_jump":{"hop_duration":1,"hop_height":1},"zuus_lightning_bolt":{"sight_duration":1},"zuus_static_field":{"damage_health_pct":1},"zuus_thundergods_wrath":{"sight_duration":1}},"limitlist":{"abaddon_borrowed_time":{"duration":{"max":250.0},"duration_scepter":{"max":250.0}},"abyssal_underlord_atrophy_aura":{"damage_reduction_pct":{"max":200.0}},"abyssal_underlord_dark_portal":{"damage_reduction":{"max":300.0}},"bloodseeker_thirst":{"invis_threshold_pct":{"max":200.0},"visibility_threshold_pct":{"max":200.0}},"bounty_hunter_wind_walk":{"damage_reduction_pct":{"max":300.0}},"faceless_void_chronosphere":{"duration":{"max":300.0}},"generic_hidden":{"duration":{"max":1.0,"min":1.0}},"item_horrendous_halberd":{"block_chance":{"max":1000.0}},"item_misericorde":{"missing_hp":{"min":10.0}},"item_muertas_gun":{"AbilityCastRange":{"max":200.0,"min":10.0}},"item_titan_sliver":{"status_resistance":{"max":900.0}},"kunkka_ghostship":{"ghostship_absorb":{"max":200.0}},"kunkka_torrent_storm":{"torrent_duration":{"max":420.0}},"leshrac_pulse_nova":{"damage_resistance":{"max":300.0}},"luna_moon_glaive":{"rotating_glaives_damage_reduction":{"max":400.0}},"medusa_stone_gaze":{"duration":{"max":500.0},"stone_duration":{"max":1000.0}},"muerta_the_calling":{"duration":{"max":300.0},"num_revenants":{"max":250.0}},"naga_siren_song_of_the_siren":{"duration":{"max":420.0}},"necrolyte_heartstopper_aura":{"heal_regen_to_damage":{"max":420.0}},"nyx_assassin_burrow":{"damage_reduction":{"max":200.0}},"skeleton_king_reincarnation":{"scepter_duration":{"max":420.0}},"slardar_sprint":{"puddle_status_resistance":{"max":225.0}},"spectre_dispersion":{"activation_duration":{"max":200.0}},"spirit_breaker_bulldoze":{"status_resistance":{"max":138.0}},"tiny_avalanche":{"tick_count":{"min":25.0}},"troll_warlord_battle_trance":{"trance_duration":{"max":420.0}},"vengefulspirit_nether_swap":{"damage_reduction":{"max":180.0}},"wildcard":{"linger_duration":{"max":420.0}},"zuus_thundergods_wrath":{"damage_pct":{"max":300.0}}},"nerflist":{"abyssal_underlord_atrophy_aura":{"ensnare_duration":0.5},"abyssal_underlord_firestorm":{"burn_damage":0.25},"all":{"area_of_effect":0.2,"attack_range_bonus":0.2,"bonus_attack_range":0.2,"interval":0.2,"radius":0.2,"sight_radius_day":0.2,"sight_radius_night":0.2,"splash_radius":0.2,"think_interval":0.2,"think_rate":0.2,"tick_interval":0.2,"tick_rate":0.2,"travel_distance":0.2,"true_sight_radius":0.2},"ancient_apparition_ice_blast":{"kill_pct":0.4000000059604645},"ancient_apparition_ice_vortex":{"vision_aoe":0.2},"batrider_firefly":{"bonus_vision":0.2,"tick_interval":0.1},"bloodseeker_thirst":{"invis_threshold_pct":0.2},"bristleback_bristleback":{"back_damage_reduction":0.1,"quill_release_threshold":0.2,"side_damage_reduction":0.1},"crystal_maiden_freezing_field":{"explosion_max_dist":0.2,"explosion_min_dist":0.2},"dark_willow_bedlam":{"attack_interval":0.2,"roaming_seconds_per_rotation":0.2},"dazzle_shallow_grave":{"duration":0.1},"drow_ranger_wave_of_silence":{"wave_length":0.4000000059604645,"wave_width":0.2},"earth_spirit_magnetize":{"damage_interval":0.2},"earthshaker_aftershock":{"aftershock_range":0.2},"enigma_midnight_pulse":{"damage_percent":0.25},"faceless_void_chronosphere":{"duration":0.5},"fiend_grip_tick_interval":{"kill_pct":0.1},"furion_curse_of_the_forest":{"range":0.2},"furion_wrath_of_nature":{"damage_percent_add":0.2},"generic_hidden":{"duration":1.0},"grimstroke_ink_creature":{"destroy_attacks":0.2},"hoodwink_acorn_shot":{"bounce_range":0.2},"hoodwink_sharpshooter":{"arrow_width":0.2},"invoker_forge_spirit":{"spirit_attack_range":0.2},"invoker_sun_strike":{"cataclysm_count":0.25},"item_helm_of_the_undying":{"duration":0.3},"jakiro_macropyre":{"linger_duration":0.2},"juggernaut_blade_fury":{"shard_attack_rate":0.2},"keeper_of_the_light_will_o_wisp":{"hit_count":0.2},"kunkka_ghostship":{"ghostship_absorb":0.1,"ghostship_distance":0.2,"ghostship_width":0.2},"leshrac_split_earth":{"shard_secondary_delay":0.2},"lich_chain_frost":{"jump_range":0.2},"lich_frost_shield":{"interval":0.2},"lich_sinister_gaze":{"aoe_scepter":0.2,"cast_range":0.2},"life_stealer_infest":{"attack_rate":0.2},"life_stealer_open_wounds":{"max_health_as_damage_pct":0.2},"life_stealer_rage":{"AbilityDuration":0.2},"lina_dragon_slave":{"dragon_slave_width_end":0.2,"dragon_slave_width_initial":0.2},"lina_laguna_blade":{"scepter_width":0.2},"lina_light_strike_array":{"light_strike_array_aoe":0.2,"light_strike_array_delay_time":0.1},"lion_impale":{"width":0.2},"luna_moon_glaive":{"range":0.2},"magnataur_shockwave":{"scepter_range":0.2,"scepter_width":0.2,"shock_width":0.2},"mars_arena_of_blood":{"spear_attack_interval":0.2},"mars_bulwark":{"physical_damage_reduction":0.1,"physical_damage_reduction_side":0.1},"mars_spear":{"spear_width":0.2},"monkey_king_wukongs_command":{"scepter_spawn_duration":0.2,"scepter_spawn_interval":0.2},"morphling_waveform":{"width":0.2},"nevermore_necromastery":{"necromastery_max_souls":0.2,"necromastery_max_souls_scepter":0.2},"nyx_assassin_burrow":{"damage_reduction":0.2},"ogre_magi_bloodlust":{"multicast_bloodlust_aoe":0.5},"ogre_magi_ignite":{"ignite_multicast_aoe":0.2},"ogre_magi_smash":{"multicast_fireshield_aoe":0.5},"oracle_false_promise":{"duration":0.2},"phantom_assassin_fan_of_knives":{"pct_health_damage_initial":0.2},"puck_illusory_orb":{"orb_vision":0.2},"puck_phase_shift":{"shard_attack_range_bonus":0.5},"pugna_nether_blast":{"structure_damage_mod":0.2},"pugna_nether_ward":{"shard_ward_bonus_cast_range":0.2},"queenofpain_blink":{"shard_aoe":0.2,"shard_duration":0.2},"queenofpain_scream_of_pain":{"area_of_effect":0.2},"queenofpain_shadow_strike":{"damage_interval":0.2},"queenofpain_sonic_wave":{"distance":0.2,"final_aoe":0.2},"rattletrap_overclocking":{"rocket_flare_rockets":0.2},"razor_eye_of_the_storm":{"strike_interval":0.2},"rubick_arcane_supremacy":{"cast_range":0.25},"rubick_telekinesis":{"max_land_distance":0.2,"shard_max_land_distance_bonus_pct":0.2},"sandking_epicenter":{"epicenter_radius":0.2,"shard_radius":0.2},"sandking_sand_storm":{"sand_storm_radius":0.2},"shadow_demon_disseminate":{"damage_reflection_pct":0.2},"shadow_demon_shadow_poison":{"radius":0.2},"shadow_shaman_ether_shock":{"end_distance":0.2},"shadow_shaman_mass_serpent_ward":{"ward_count":0.5},"shadow_shaman_shackles":{"shard_ward_count":0.5,"shard_ward_spawn_distance":0.2},"silencer_glaives_of_wisdom":{"permanent_int_steal_range":0.2,"shard_range":0.2},"skywrath_mage_arcane_bolt":{"scepter_radius":0.2},"skywrath_mage_concussive_shot":{"shot_vision":0.2},"slark_shadow_dance":{"duration":0.2},"spectre_dispersion":{"damage_reflection_pct":0.1},"spirit_breaker_charge_of_darkness":{"movement_speed":0.5},"storm_spirit_ball_lightning":{"ball_lightning_aoe":0.2,"ball_lightning_move_speed":0.2,"scepter_remnant_interval":0.2},"storm_spirit_electric_vortex":{"electric_vortex_pull_tether_range":0.2},"storm_spirit_overload":{"overload_aoe":0.2},"techies_land_mines":{"building_damage_pct":0.25,"mres_reduction":0.25},"terrorblade_reflection":{"range":0.2},"tidehunter_arm_of_the_deep":{"damage_pct":0.2,"range_pct":0.2},"tidehunter_kraken_shell":{"damage_cleanse":0.2},"treant_leech_seed":{"damage_interval":0.2},"troll_warlord_whirling_axes_melee":{"hit_radius":0.2},"troll_warlord_whirling_axes_ranged":{"axe_range":0.2,"axe_width":0.2},"undying_tombstone":{"zombie_interval":0.2},"ursa_earthshock":{"shard_enrage_duration":0.1},"ursa_enrage":{"status_resistance":0.25},"vengefulspirit_wave_of_terror":{"vision_aoe":0.2,"wave_width":0.2},"viper_corrosive_skin":{"effect_multiplier":0.1},"viper_poison_attack":{"shard_building_dmg_pct":0.25},"void_spirit_astral_step":{"max_travel_distance":0.2},"warlock_fatal_bonds":{"shard_aoe":0.2,"tick_interval":0.2},"warlock_rain_of_chaos":{"aoe":0.2},"warlock_upheaval":{"aoe":0.2,"tick_interval":0.2},"warpine_raider_seed_shot":{"bounce_range":0.2},"weaver_the_swarm":{"attack_rate":0.1,"destroy_attacks":0.2},"wildcard":{"_aoe":0.2,"distance":0.2,"radius":0.2,"range":0.2},"windrunner_powershot":{"arrow_range":0.2},"winter_wyvern_arctic_burn":{"attack_point":0.2,"night_vision_bonus":0.2},"winter_wyvern_cold_embrace":{"shard_splinter_range":0.2},"witch_doctor_paralyzing_cask":{"bounce_range":0.2},"zuus_arc_lightning":{"damage_health_pct":0.25},"zuus_cloud":{"cloud_bolt_interval":0.2},"zuus_heavenly_jump":{"range":0.2},"zuus_lightning_bolt":{"spread_aoe":0.2},"zuus_thundergods_wrath":{"damage":0.3}}}
+{
+    "blocklist": {
+        "abaddon_frostmourne": {
+            "curse_duration": 1,
+            "slow_duration": 1
+        },
+        "abyssal_underlord_atrophy_aura": {
+            "pit_duration": 1
+        },
+        "abyssal_underlord_dark_portal": {
+            "duration": 1
+        },
+        "abyssal_underlord_pit_of_malice": {
+            "ensnare_duration": 1,
+            "pit_damage": 1
+        },
+        "alchemist_chemical_rage": {
+            "bonus_health": 1,
+            "bonus_mana_regen": 1,
+            "scepter_gold_damage": 1
+        },
+        "alchemist_unstable_concoction": {
+            "brew_time": 1,
+            "max_damage": 1,
+            "max_stun": 1,
+            "min_damage": 1,
+            "min_stun": 1,
+            "radius": 1
+        },
+        "alchemist_unstable_concoction_throw": {
+            "brew_time": 1,
+            "max_damage": 1,
+            "min_damage": 1,
+            "vision_range": 1
+        },
+        "all": {
+            "AbilityCastPoint": 1,
+            "AbilityCastRange": 1,
+            "AbilityCharges": 1,
+            "AbilityCooldown": 1,
+            "AbilityManaCost": 1,
+            "CalculateSpellDamageTooltip": 1,
+            "DamageTypeTooltip": 1,
+            "LinkedSpecialBonus": 1,
+            "LinkedSpecialBonusField": 1,
+            "LinkedSpecialBonusOperation": 1,
+            "RequiresScepter": 1,
+            "RequiresShard": 1,
+            "ability_capture": 1,
+            "ability_lamp_use": 1,
+            "ability_pluck_famango": 1,
+            "abyssal_underlord_portal_warp": 1,
+            "ad_linked_abilities": 1,
+            "bonus_cdr": 1,
+            "cannot_be_dispelled": 1,
+            "cooldown_reduction": 1,
+            "crit_chance": 1,
+            "dispel": 1,
+            "familiar_armor": 1,
+            "familiar_attack_damage": 1,
+            "familiar_hp": 1,
+            "familiar_speed": 1,
+            "generic_hidden": 1,
+            "kunkka_x_marks_the_spot": 1,
+            "levelkey": 1,
+            "lycan_summon_wolves": 1,
+            "max_invoked_spells": 1,
+            "pierce_immunity": 1,
+            "pierces_immunity": 1,
+            "pierces_magic_immunity": 1,
+            "respawn": 1,
+            "special_bonus_attributes": 1,
+            "tusk_frozen_sigil": 1,
+            "twin_gate_portal_warp": 1,
+            "undispellable": 1,
+            "var_type": 1,
+            "venomancer_plague_ward": 1,
+            "visage_stone_form_self_cast": 1
+        },
+        "ancient_apparition_cold_feet": {
+            "AbilityCharges": 1,
+            "AbilityDuration": 1,
+            "area_of_effect": 1
+        },
+        "ancient_apparition_ice_vortex": {
+            "drag_speed": 1
+        },
+        "antimage_blink": {
+            "min_blink_range": 1
+        },
+        "antimage_counterspell": {
+            "min_blink_range": 1
+        },
+        "antimage_mana_break": {
+            "silence_chance": 1,
+            "silence_duration": 1
+        },
+        "arc_warden_tempest_double": {
+            "tempest_double_cooldown_reduction": 1
+        },
+        "axe_counter_helix": {
+            "cooldown": 1,
+            "shard_bonus_chance": 1,
+            "trigger_chance": 1
+        },
+        "axe_culling_blade": {
+            "charge_speed": 1
+        },
+        "bane_nightmare": {
+            "AbilityDuration": 1,
+            "animation_rate": 1,
+            "nightmare_invuln_time": 1
+        },
+        "batrider_flamebreak": {
+            "collision_radius": 1,
+            "knockback_height": 1
+        },
+        "batrider_flaming_lasso": {
+            "allied_cooldown": 1,
+            "grab_radius": 1
+        },
+        "beastmaster_drums_of_slom": {
+            "AbilityDuration": 1,
+            "movespeed_slow": 1
+        },
+        "beastmaster_inner_beast": {
+            "scepter_cooldown": 1,
+            "scepter_duration": 1,
+            "scepter_manacost": 1,
+            "scepter_multiplier": 1,
+            "scepter_radius": 1
+        },
+        "beastmaster_wild_axes": {
+            "range": 1,
+            "scepter_cooldown": 1
+        },
+        "bounty_hunter_shuriken_toss": {
+            "cast_range": 1,
+            "scepter_cooldown": 1
+        },
+        "bounty_hunter_track": {
+            "bonus_gold_radius": 1,
+            "gold_steal": 1
+        },
+        "bounty_hunter_wind_walk": {
+            "shard_damage_reduction_pct": 1
+        },
+        "brewmaster_drunken_brawler": {
+            "slow_duration": 1
+        },
+        "bristleback_bristleback": {
+            "back_angle": 1,
+            "side_angle": 1
+        },
+        "centaur_double_edge": {
+            "scepter_range": 1
+        },
+        "centaur_stampede": {
+            "base_damage": 1
+        },
+        "chaos_knight_chaos_bolt": {
+            "fake_bolt_distance": 1
+        },
+        "chaos_knight_chaos_strike": {
+            "chance": 1
+        },
+        "chaos_knight_phantasm": {
+            "magic_resistance": 1,
+            "outgoing_damage": 1,
+            "vision_radius": 1
+        },
+        "chaos_knight_reality_rift": {
+            "cast_range": 1
+        },
+        "chen_divine_favor": {
+            "teleport_delay": 1
+        },
+        "chen_hand_of_god": {
+            "ancient_creeps_scepter": 1,
+            "does_purge": 1
+        },
+        "chen_holy_persuasion": {
+            "AbilityCharges": 1,
+            "is_martyr": 1
+        },
+        "crystal_maiden_freezing_field": {
+            "can_move": 1
+        },
+        "crystal_maiden_frostbite": {
+            "tick_interval": 1
+        },
+        "dark_seer_ion_shell": {
+            "tick_interval": 1
+        },
+        "dark_seer_surge": {
+            "AbilityCharges": 1
+        },
+        "dark_seer_wall_of_replica": {
+            "replica_damage_incoming": 1,
+            "replica_damage_outgoing": 1,
+            "replica_scale": 1
+        },
+        "dark_willow_bedlam": {
+            "attack_targets": 1
+        },
+        "dark_willow_bramble_maze": {
+            "initial_creation_delay": 1,
+            "latch_creation_delay": 1,
+            "latch_creation_interval": 1,
+            "latch_range": 1,
+            "placement_count": 1,
+            "placement_range": 1
+        },
+        "dark_willow_shadow_realm": {
+            "duration": 1,
+            "scepter_radius": 1
+        },
+        "dark_willow_terrorize": {
+            "starting_height": 1,
+            "telegraph_to_enemies": 1
+        },
+        "dawnbreaker_fire_wreath": {
+            "animation_rate": 1,
+            "total_attacks": 1,
+            "turn_rate": 1
+        },
+        "dawnbreaker_luminosity": {
+            "attack_count": 1
+        },
+        "dazzle_poison_touch": {
+            "bonus_damage": 1
+        },
+        "dazzle_shallow_grave": {
+            "fx_halo_height": 1
+        },
+        "death_prophet_carrion_swarm": {
+            "end_radius": 1,
+            "start_radius": 1
+        },
+        "death_prophet_exorcism": {
+            "average_damage": 1,
+            "ghost_spawn_rate": 1,
+            "give_up_distance": 1,
+            "max_distance": 1,
+            "radius": 1,
+            "scepter_movespeed_slow": 1,
+            "scepter_spirit_life_duration": 1,
+            "spirit_speed": 1
+        },
+        "death_prophet_silence": {
+            "projectile_speed": 1
+        },
+        "death_prophet_spirit_siphon": {
+            "AbilityChargeRestoreTime": 1,
+            "movement_steal": 1
+        },
+        "disruptor_glimpse": {
+            "backtrack_time": 1,
+            "cast_range": 1,
+            "silence_duration": 1
+        },
+        "disruptor_kinetic_field": {
+            "damage_per_second": 1
+        },
+        "doom_bringer_devour": {
+            "armor": 1,
+            "bonus_gold": 1,
+            "creep_level": 1,
+            "hero_ability_steal_time": 1
+        },
+        "doom_bringer_doom": {
+            "deniable_pct": 1,
+            "scepter_cooldown": 1
+        },
+        "doom_bringer_scorched_earth": {
+            "damage_per_hero": 1
+        },
+        "dragon_knight_elder_dragon_form": {
+            "bonus_attack_damage": 1,
+            "magic_resistance": 1,
+            "model_scale": 1
+        },
+        "dragon_knight_fireball": {
+            "burn_interval": 1
+        },
+        "drow_ranger_multishot": {
+            "arrow_count_per_wave": 1,
+            "bypass_block": 1,
+            "wave_count": 1
+        },
+        "earth_spirit_boulder_smash": {
+            "rock_search_aoe": 1
+        },
+        "earth_spirit_geomagnetic_grip": {
+            "total_pull_distance": 1
+        },
+        "earth_spirit_rolling_boulder": {
+            "damage_str": 1
+        },
+        "earthshaker_enchant_totem": {
+            "scepter_acceleration_horizontal": 1,
+            "scepter_acceleration_z": 1,
+            "scepter_cleave_ending_width": 1,
+            "scepter_cleave_starting_width": 1,
+            "scepter_height": 1,
+            "scepter_height_arcbuffer": 1
+        },
+        "earthshaker_fissure": {
+            "fissure_radius": 1,
+            "fissure_range": 1
+        },
+        "elder_titan_ancestral_spirit": {
+            "move_pct_cap": 1,
+            "speed": 1
+        },
+        "elder_titan_earth_splitter": {
+            "speed": 1,
+            "total_steps": 1,
+            "vision_duration": 1,
+            "vision_interval": 1,
+            "vision_step": 1,
+            "vision_width": 1
+        },
+        "elder_titan_echo_stomp": {
+            "animation_rate": 1,
+            "cast_time": 1
+        },
+        "ember_spirit_activate_fire_remnant": {
+            "charge_restore_time": 1,
+            "damage": 1,
+            "max_charges": 1,
+            "scepter_mana_cost": 1,
+            "shard_remnant_speed_pct": 1,
+            "speed_multiplier": 1
+        },
+        "ember_spirit_fire_remnant": {
+            "AbilityChargeRestoreTime": 1,
+            "duration": 1
+        },
+        "ember_spirit_flame_guard": {
+            "AbilityChargeRestoreTime": 1,
+            "blind_pct": 1
+        },
+        "ember_spirit_searing_chains": {
+            "radius_scepter": 1
+        },
+        "ember_spirit_sleight_of_fist": {
+            "AbilityCharges": 1,
+            "creep_damage_penalty": 1
+        },
+        "enchantress_bunny_hop": {
+            "hop_duration": 1,
+            "hop_height": 1
+        },
+        "enchantress_natures_attendants": {
+            "heal_interval": 1,
+            "movespeed": 1,
+            "shard_permanent_wisp_count": 1
+        },
+        "enigma_black_hole": {
+            "animation_rate": 1,
+            "duration": 1,
+            "tick_rate": 1,
+            "vision_radius": 1
+        },
+        "enigma_midnight_pulse": {
+            "duration": 1
+        },
+        "enraged_wildkin_tornado": {
+            "AbilityChannelTime": 1
+        },
+        "faceless_void_chronosphere": {
+            "bonus_attack_speed": 1,
+            "vision_radius": 1
+        },
+        "furion_force_of_nature": {
+            "treant_large_damage_bonus": 1,
+            "treant_large_hp_bonus": 1
+        },
+        "furion_sprout": {
+            "sprout_damage_inteval": 1,
+            "vision_range": 1
+        },
+        "generic_hidden": {
+            "duration": 1
+        },
+        "grimstroke_dark_artistry": {
+            "abilitycastrange": 1,
+            "end_radius": 1,
+            "start_radius": 1
+        },
+        "grimstroke_ink_creature": {
+            "hero_attack_multiplier": 1,
+            "infection_search_radius": 1,
+            "latched_unit_offset": 1,
+            "latched_unit_offset_short": 1,
+            "return_projectile_speed": 1,
+            "spawn_time": 1,
+            "tick_interval": 1
+        },
+        "grimstroke_soul_chain": {
+            "chain_break_distance": 1,
+            "creep_duration_pct": 1,
+            "leash_limit_multiplier": 1,
+            "leash_radius_buffer": 1
+        },
+        "grimstroke_spirit_walk": {
+            "tick_rate": 1
+        },
+        "gyrocopter_call_down": {
+            "damage_second_scepter": 1,
+            "range_scepter": 1
+        },
+        "gyrocopter_flak_cannon": {
+            "fire_rate": 1,
+            "projectile_speed": 1,
+            "scepter_radius": 1
+        },
+        "gyrocopter_homing_missile": {
+            "attack_speed_bonus_pct": 1
+        },
+        "gyrocopter_rocket_barrage": {
+            "rockets_per_second": 1
+        },
+        "hoodwink_acorn_shot": {
+            "bounce_delay": 1
+        },
+        "hoodwink_bushwhack": {
+            "animation_rate": 1,
+            "visual_height": 1
+        },
+        "hoodwink_decoy": {
+            "projectile_speed": 1
+        },
+        "invoker_chaos_meteor": {
+            "end_vision_duration": 1,
+            "meteor_count": 1,
+            "vision_distance": 1
+        },
+        "invoker_deafening_blast": {
+            "end_vision_duration": 1,
+            "radius_end": 1,
+            "radius_start": 1
+        },
+        "invoker_forge_spirit": {
+            "armor_per_attack": 1,
+            "extra_spirit_count_exort": 1,
+            "extra_spirit_count_quas": 1
+        },
+        "invoker_ice_wall": {
+            "num_wall_elements": 1,
+            "wall_element_radius": 1,
+            "wall_element_spacing": 1,
+            "wall_place_distance": 1
+        },
+        "invoker_sun_strike": {
+            "delay": 1,
+            "vision_distance": 1,
+            "vision_duration": 1
+        },
+        "invoker_tornado": {
+            "end_vision_duration": 1,
+            "quas_damage": 1,
+            "vision_distance": 1
+        },
+        "item_aegis": {
+            "disappear_time_turbo": 1
+        },
+        "item_aeon_disk": {
+            "max_level": 1
+        },
+        "item_afterburner": {
+            "tick_rate": 1
+        },
+        "item_armlet": {
+            "unholy_bonus_attack_speed": 1
+        },
+        "item_black_king_bar": {
+            "max_level": 1
+        },
+        "item_blade_mail": {
+            "bonus_intellect": 1
+        },
+        "item_blink": {
+            "blink_range": 1,
+            "blink_range_clamp": 1
+        },
+        "item_bottle": {
+            "max_charges": 1
+        },
+        "item_heart": {
+            "bonus_strength": 1
+        },
+        "item_mirror_shield": {
+            "block_cooldown": 1
+        },
+        "item_moon_shard": {
+            "consumed_bonus": 1
+        },
+        "item_obsidian_pauldrons": {
+            "tick_rate": 1
+        },
+        "item_octarine_core": {
+            "bonus_cooldown": 1
+        },
+        "item_orb_of_contagion": {
+            "tick_rate": 1
+        },
+        "item_power_treads": {
+            "bonus_damage": 1
+        },
+        "item_quickening_charm": {
+            "bonus_cooldown": 1
+        },
+        "item_radiance": {
+            "upgrade_day_vision": 1
+        },
+        "item_ruthless_dagger": {
+            "tick_rate": 1
+        },
+        "item_spell_prism": {
+            "bonus_cooldown": 1
+        },
+        "item_tpscroll": {
+            "AbilityChannelTime": 1,
+            "minimun_distance": 1,
+            "vision_radius": 1
+        },
+        "item_travel_boots_2": {
+            "tp_channel_time": 1
+        },
+        "item_wand_of_the_brine": {
+            "damage_reduction": 1
+        },
+        "jakiro_dual_breath": {
+            "end_radius": 1,
+            "fire_delay": 1,
+            "range": 1,
+            "speed": 1,
+            "speed_fire": 1,
+            "start_radius": 1
+        },
+        "jakiro_liquid_ice": {
+            "stun_duration": 1
+        },
+        "jakiro_macropyre": {
+            "burn_interval": 1,
+            "cast_range": 1
+        },
+        "juggernaut_blade_dance": {
+            "blade_dance_lifesteal": 1
+        },
+        "juggernaut_blade_fury": {
+            "blade_fury_damage_tick": 1,
+            "duration": 1
+        },
+        "keeper_of_the_light_blinding_light": {
+            "AbilityCharges": 1
+        },
+        "keeper_of_the_light_chakra_magic": {
+            "duration": 1,
+            "mana_leak_pct": 1
+        },
+        "keeper_of_the_light_illuminate": {
+            "channel_vision_duration": 1,
+            "channel_vision_interval": 1,
+            "channel_vision_radius": 1,
+            "channel_vision_step": 1,
+            "max_channel_time": 1,
+            "vision_duration": 1
+        },
+        "keeper_of_the_light_spirit_form_illuminate": {
+            "channel_vision_duration": 1,
+            "channel_vision_interval": 1,
+            "channel_vision_radius": 1,
+            "channel_vision_step": 1,
+            "max_channel_time": 1,
+            "vision_duration": 1
+        },
+        "kunkka_tidebringer": {
+            "cleave_ending_width": 1,
+            "cleave_starting_width": 1
+        },
+        "legion_commander_duel": {
+            "victory_range": 1
+        },
+        "legion_commander_moment_of_courage": {
+            "buff_duration": 1,
+            "trigger_chance": 1
+        },
+        "leshrac_diabolic_edict": {
+            "abilityduration": 1,
+            "shard_max_count": 1,
+            "tower_bonus": 1
+        },
+        "leshrac_lightning_storm": {
+            "interval_scepter": 1,
+            "radius_scepter": 1
+        },
+        "leshrac_split_earth": {
+            "shard_max_count": 1
+        },
+        "lich_chain_frost": {
+            "vision_radius": 1
+        },
+        "lich_frost_shield": {
+            "damage_reduction": 1,
+            "duration": 1
+        },
+        "life_stealer_infest": {
+            "damage_increase_pct": 1,
+            "damage_threshold": 1
+        },
+        "life_stealer_rage": {
+            "duration": 1
+        },
+        "lina_dragon_slave": {
+            "AbilityDuration": 1,
+            "dragon_slave_distance": 1,
+            "dragon_slave_speed": 1
+        },
+        "lina_fiery_soul": {
+            "fiery_soul_max_stacks": 1
+        },
+        "lina_flame_cloak": {
+            "visualzdelta": 1
+        },
+        "lina_laguna_blade": {
+            "cast_range_scepter": 1,
+            "damage_delay": 1,
+            "scepter_width": 1
+        },
+        "lion_finger_of_death": {
+            "damage_delay": 1
+        },
+        "lion_impale": {
+            "length_buffer": 1,
+            "speed": 1
+        },
+        "lion_mana_drain": {
+            "tick_interval": 1
+        },
+        "lone_druid_savage_roar": {
+            "only_affects_player_units": 1
+        },
+        "lone_druid_spirit_bear": {
+            "bear_armor": 1,
+            "bear_hp": 1,
+            "bear_regen_tooltip": 1,
+            "cooldown_scepter": 1
+        },
+        "luna_lucent_beam": {
+            "search_radius": 1
+        },
+        "lycan_summon_wolves_invisibility": {
+            "fade_time": 1
+        },
+        "magnataur_empower": {
+            "cleave_ending_width": 1,
+            "cleave_starting_width": 1
+        },
+        "magnataur_horn_toss": {
+            "destination_offset": 1,
+            "pull_angle": 1,
+            "pull_offset": 1
+        },
+        "magnataur_reverse_polarity": {
+            "pull_duration": 1
+        },
+        "magnataur_skewer": {
+            "skewer_cooldown": 1,
+            "skewer_manacost": 1,
+            "tool_attack_slow": 1
+        },
+        "marci_companion_run": {
+            "impact_position_offset": 1,
+            "max_acceleration": 1,
+            "max_lob_travel_time": 1,
+            "min_acceleration": 1,
+            "min_height_above_highest": 1,
+            "min_height_above_lowest": 1,
+            "min_lob_travel_time": 1,
+            "move_speed": 1,
+            "scepter_armor": 1,
+            "scepter_heal": 1,
+            "target_abort_distance": 1,
+            "vector_preview_radius": 1
+        },
+        "marci_grapple": {
+            "pull_angle": 1,
+            "pull_offset": 1
+        },
+        "marci_guardian": {
+            "bonus_attack_range": 1
+        },
+        "marci_unleash": {
+            "shard_push_length": 1
+        },
+        "mars_arena_of_blood": {
+            "first_warrior_angle": 1,
+            "formation_time": 1,
+            "spear_distance_from_wall": 1,
+            "warrior_count": 1,
+            "warrior_fade_max_dist": 1,
+            "warrior_fade_min_dist": 1,
+            "width": 1
+        },
+        "mars_bulwark": {
+            "forward_angle": 1,
+            "redirect_chance": 1,
+            "redirect_range": 1,
+            "side_angle": 1,
+            "soldier_count": 1,
+            "soldier_offset": 1
+        },
+        "mars_gods_rebuke": {
+            "activity_duration": 1,
+            "scepter_cooldown": 1
+        },
+        "mars_spear": {
+            "activity_duration": 1,
+            "knockback_distance": 1,
+            "knockback_duration": 1,
+            "shard_interval": 1,
+            "shard_trail_duration": 1
+        },
+        "medusa_cold_blooded": {
+            "damage": 1
+        },
+        "medusa_mystic_snake": {
+            "jump_delay": 1,
+            "stone_form_scepter_base": 1
+        },
+        "meepo_poof": {
+            "AbilityChannelTime": 1
+        },
+        "mirana_invis": {
+            "duration": 1
+        },
+        "mirana_leap": {
+            "leap_acceleration": 1
+        },
+        "monkey_king_boundless_strike": {
+            "soldier_spawn_duration": 1
+        },
+        "monkey_king_tree_dance": {
+            "perched_spot_height": 1,
+            "range": 1,
+            "top_level_height": 1
+        },
+        "monkey_king_wukongs_command": {
+            "cast_range_scepter": 1,
+            "duration": 1,
+            "leadership_radius_buffer": 1,
+            "outer_attack_buffer": 1
+        },
+        "morphling_morph_agi": {
+            "bonus_attributes": 1,
+            "castable_while_stunned": 1,
+            "morph_cooldown": 1
+        },
+        "morphling_morph_str": {
+            "bonus_attributes": 1,
+            "castable_while_stunned": 1,
+            "morph_cooldown": 1
+        },
+        "morphling_waveform": {
+            "AbilityCharges": 1,
+            "abilitycastrange": 1
+        },
+        "muerta_the_calling": {
+            "debug_draw": 1,
+            "rotation_direction": 1,
+            "rotation_initial": 1,
+            "show_warning": 1
+        },
+        "naga_siren_rip_tide": {
+            "debuff_duration": 1
+        },
+        "naga_siren_song_of_the_siren": {
+            "animation_rate": 1,
+            "regen_rate": 1,
+            "regen_rate_self": 1,
+            "scepter_cooldown": 1
+        },
+        "necrolyte_death_pulse": {
+            "projectile_speed": 1
+        },
+        "necrolyte_death_seeker": {
+            "projectile_multiplier": 1
+        },
+        "necrolyte_heartstopper_aura": {
+            "aura_radius": 1
+        },
+        "nevermore_necromastery": {
+            "attack_range_bonus": 1,
+            "necromastery_soul_release": 1
+        },
+        "nevermore_shadowraze1": {
+            "shadowraze_cooldown": 1
+        },
+        "nevermore_shadowraze2": {
+            "shadowraze_cooldown": 1
+        },
+        "nevermore_shadowraze3": {
+            "shadowraze_cooldown": 1
+        },
+        "nyx_assassin_impale": {
+            "length": 1,
+            "width": 1
+        },
+        "nyx_assassin_mana_burn": {
+            "aoe": 1
+        },
+        "nyx_assassin_spiked_carapace": {
+            "bonus_armor": 1,
+            "bonus_damage": 1,
+            "bonus_intellect": 1
+        },
+        "nyx_assassin_vendetta": {
+            "fade_time": 1,
+            "health_regen_rate_scepter": 1,
+            "mana_regen_rate_scepter": 1
+        },
+        "obsidian_destroyer_arcane_orb": {
+            "bounce_radius": 1
+        },
+        "obsidian_destroyer_astral_imprisonment": {
+            "scepter_range_bonus": 1
+        },
+        "obsidian_destroyer_equilibrium": {
+            "mana_capacity_duration": 1,
+            "mana_capacity_steal": 1,
+            "shard_bonus_mana": 1,
+            "shard_mana_duration": 1
+        },
+        "obsidian_destroyer_sanity_eclipse": {
+            "cast_range": 1
+        },
+        "ogre_magi_bloodlust": {
+            "modelscale": 1
+        },
+        "ogre_magi_smash": {
+            "projectile_speed": 1
+        },
+        "oracle_false_promise": {
+            "radius": 1
+        },
+        "oracle_fortunes_end": {
+            "scepter_bonus_radius": 1,
+            "scepter_bonus_range": 1,
+            "scepter_stun_percentage": 1
+        },
+        "pangolier_gyroshell": {
+            "tick_interval": 1,
+            "turn_rate_boosted": 1
+        },
+        "pangolier_lucky_shot": {
+            "slow": 1
+        },
+        "pangolier_rollup": {
+            "bounce_duration": 1,
+            "cast_time_tooltip": 1,
+            "forward_move_speed": 1,
+            "hit_radius": 1,
+            "jump_recover_time": 1,
+            "knockback_radius": 1,
+            "radius": 1,
+            "stun_duration": 1,
+            "tick_interval": 1,
+            "turn_rate": 1,
+            "turn_rate_boosted": 1
+        },
+        "pangolier_shield_crash": {
+            "duration": 1
+        },
+        "pangolier_swashbuckle": {
+            "attack_interval": 1,
+            "dash_range": 1,
+            "end_radius": 1,
+            "start_radius": 1
+        },
+        "phantom_assassin_fan_of_knives": {
+            "degen": 1,
+            "max_damage_initial": 1,
+            "pct_health_damage": 1
+        },
+        "phantom_assassin_phantom_strike": {
+            "AbilityCharges": 1,
+            "abilitycastrange": 1
+        },
+        "phantom_assassin_stifling_dagger": {
+            "attack_factor": 1
+        },
+        "phantom_lancer_doppelwalk": {
+            "illusion_1_damage_in_pct": 1
+        },
+        "phantom_lancer_spirit_lance": {
+            "fake_lance_distance": 1
+        },
+        "phoenix_fire_spirits": {
+            "attackspeed_slow": 1,
+            "damage_per_second": 1,
+            "duration": 1,
+            "radius": 1,
+            "spirit_count": 1,
+            "spirit_speed": 1,
+            "tick_interval": 1
+        },
+        "phoenix_launch_fire_spirit": {
+            "hp_cost_perc": 1,
+            "spirit_count": 1,
+            "spirit_duration": 1
+        },
+        "phoenix_sun_ray": {
+            "tick_interval": 1,
+            "turn_rate_initial": 1
+        },
+        "primal_beast_onslaught": {
+            "chargeup_time": 1,
+            "max_charge_time": 1
+        },
+        "primal_beast_pulverize": {
+            "animation_rate": 1,
+            "cast_range": 1,
+            "pierce_immunity": 1
+        },
+        "primal_beast_rock_throw": {
+            "bounce_travel_time": 1,
+            "fragment_impact_distance": 1,
+            "fragment_impact_radius": 1
+        },
+        "primal_beast_trample": {
+            "step_distance": 1
+        },
+        "primal_beast_uproar": {
+            "damage_max": 1,
+            "damage_min": 1,
+            "roared_bonus_attack_speed": 1,
+            "should_dispell": 1
+        },
+        "pudge_dismember": {
+            "abilitychanneltime": 1,
+            "animation_rate": 1,
+            "order_lock_duration": 1,
+            "pull_distance_limit": 1,
+            "pull_units_per_second": 1
+        },
+        "pudge_meat_hook": {
+            "hook_distance": 1,
+            "vector_target_distance": 1,
+            "vision_duration": 1,
+            "vision_radius": 1
+        },
+        "pudge_rot": {
+            "rot_tick": 1
+        },
+        "pugna_decrepify": {
+            "abilityduration": 1,
+            "bonus_movement_speed_allies": 1
+        },
+        "pugna_life_drain": {
+            "scepter_cooldown": 1,
+            "tick_rate": 1
+        },
+        "pugna_nether_ward": {
+            "mana_regen": 1,
+            "spell_damage_reduction": 1
+        },
+        "queenofpain_scream_of_pain": {
+            "projectile_speed": 1
+        },
+        "queenofpain_sonic_wave": {
+            "starting_aoe": 1
+        },
+        "rattletrap_hookshot": {
+            "cooldown_scepter": 1
+        },
+        "rattletrap_overclocking": {
+            "bonus_movement_speed": 1,
+            "buff_duration": 1,
+            "rocket_flare_cooldown": 1,
+            "rocket_flare_rockets": 1
+        },
+        "rattletrap_power_cogs": {
+            "bonus_armor": 1,
+            "extra_pull_buffer": 1,
+            "leash": 1
+        },
+        "rattletrap_rocket_flare": {
+            "AbilityCooldown": 1,
+            "damage": 1
+        },
+        "razor_static_link": {
+            "radius": 1,
+            "vision_duration": 1,
+            "vision_radiuss": 1
+        },
+        "riki_backstab": {
+            "backstab_angle": 1
+        },
+        "riki_blink_strike": {
+            "AbilityChargeRestoreTime": 1,
+            "abilitycastrange": 1
+        },
+        "riki_smoke_screen": {
+            "duration": 1
+        },
+        "riki_tricks_of_the_trade": {
+            "AbilityChannelTime": 1,
+            "damage_pct": 1,
+            "dispel": 1,
+            "scepter_cast_range": 1,
+            "scepter_duration": 1
+        },
+        "rubick_telekinesis": {
+            "fall_duration": 1,
+            "shard_teammate_throw_delay": 1
+        },
+        "rubick_telekinesis_land": {
+            "radius": 1
+        },
+        "rubick_telekinesis_land_self": {
+            "radius": 1
+        },
+        "sandking_burrowstrike": {
+            "burrow_anim_time": 1,
+            "burrow_speed": 1,
+            "burrow_speed_scepter": 1
+        },
+        "sandking_epicenter": {
+            "epicenter_pulses": 1
+        },
+        "sandking_sand_storm": {
+            "damage_tick_rate": 1,
+            "fade_delay": 1
+        },
+        "shadow_demon_disruption": {
+            "AbilityCharges": 1,
+            "illusion_bounty_base": 1,
+            "illusion_bounty_growth": 1
+        },
+        "shadow_demon_soul_catcher": {
+            "illusion_incoming_damage": 1,
+            "illusion_outgoing_damage": 1
+        },
+        "shadow_shaman_ether_shock": {
+            "end_radius": 1,
+            "start_radius": 1
+        },
+        "shadow_shaman_mass_serpent_ward": {
+            "scepter_range": 1
+        },
+        "shadow_shaman_shackles": {
+            "AbilityChannelTime": 1,
+            "tick_interval": 1
+        },
+        "shredder_chakram": {
+            "castpoint_scepter": 1,
+            "damage_interval": 1
+        },
+        "shredder_chakram_2": {
+            "castpoint_scepter": 1,
+            "damage_interval": 1
+        },
+        "shredder_flamethrower": {
+            "building_dmg_pct": 1
+        },
+        "shredder_timber_chain": {
+            "chain_radius": 1
+        },
+        "shredder_whirling_death": {
+            "whirling_tick": 1
+        },
+        "silencer_glaives_of_wisdom": {
+            "AbilityDuration": 1
+        },
+        "silencer_last_word": {
+            "scepter_bonus_damage": 1
+        },
+        "skeleton_king_vampiric_aura": {
+            "gold_bounty": 1,
+            "xp_bounty": 1
+        },
+        "skywrath_mage_arcane_bolt": {
+            "bolt_vision": 1,
+            "vision_duration": 1
+        },
+        "skywrath_mage_mystic_flare": {
+            "damage_interval": 1
+        },
+        "skywrath_mage_shield_of_the_scion": {
+            "stack_duration": 1
+        },
+        "slardar_amplify_damage": {
+            "undispellable": 1
+        },
+        "slark_dark_pact": {
+            "pulse_duration": 1,
+            "pulse_interval": 1,
+            "total_pulses": 1
+        },
+        "slark_pounce": {
+            "pounce_acceleration": 1,
+            "pounce_speed": 1
+        },
+        "slark_shadow_dance": {
+            "activation_delay": 1,
+            "fade_time": 1,
+            "neutral_disable": 1
+        },
+        "snapfire_firesnap_cookie": {
+            "jump_duration": 1,
+            "jump_height": 1,
+            "landing_gesture_duration": 1,
+            "pre_hop_duration": 1,
+            "pre_land_anim_time": 1,
+            "self_cast_delay": 1,
+            "target_heal": 1
+        },
+        "snapfire_mortimer_kisses": {
+            "burn_interval": 1,
+            "delay_after_last_projectile": 1,
+            "dist_change_speed": 1,
+            "max_lob_travel_time": 1,
+            "min_lob_travel_time": 1,
+            "projectile_count": 1,
+            "projectile_speed": 1,
+            "projectile_vision": 1,
+            "projectile_width": 1,
+            "turn_rate": 1
+        },
+        "snapfire_scatterblast": {
+            "blast_speed": 1,
+            "blast_width_end": 1,
+            "blast_width_initial": 1,
+            "point_blank_range": 1
+        },
+        "snapfire_spit_creep": {
+            "burn_interval": 1,
+            "dist_change_speed": 1,
+            "max_acceleration": 1,
+            "max_lob_travel_time": 1,
+            "min_acceleration": 1,
+            "min_height_above_highest": 1,
+            "min_height_above_lowest": 1,
+            "min_lob_travel_time": 1,
+            "min_range": 1,
+            "projectile_speed": 1,
+            "projectile_vision": 1,
+            "projectile_width": 1,
+            "turn_rate": 1
+        },
+        "sniper_assassinate": {
+            "abilitycastpoint": 1,
+            "scatter_damage_pct": 1,
+            "scatter_range": 1,
+            "scatter_width": 1,
+            "scepter_crit": 1
+        },
+        "sniper_shrapnel": {
+            "AbilityCharges": 1
+        },
+        "spectre_haunt": {
+            "attack_delay": 1
+        },
+        "spectre_haunt_single": {
+            "attack_delay": 1
+        },
+        "spirit_breaker_charge_of_darkness": {
+            "scepter_cast_point": 1,
+            "scepter_speed": 1,
+            "vision_duration": 1,
+            "vision_radius": 1
+        },
+        "spirit_breaker_greater_bash": {
+            "bonus_movespeed_pct": 1,
+            "movespeed_duration": 1
+        },
+        "spirit_breaker_nether_strike": {
+            "fade_time": 1,
+            "shard_bonus_damage": 1,
+            "shard_break_duration": 1,
+            "shard_spell_immune_duration": 1
+        },
+        "storm_spirit_ball_lightning": {
+            "ball_lightning_initial_mana_percentage": 1,
+            "ball_lightning_travel_cost_base": 1,
+            "ball_lightning_vision_radius": 1,
+            "blocker_duration": 1
+        },
+        "storm_spirit_electric_vortex": {
+            "abilityduration": 1
+        },
+        "sven_great_cleave": {
+            "cleave_starting_width": 1
+        },
+        "sven_storm_bolt": {
+            "vision_radius": 1
+        },
+        "techies_land_mines": {
+            "AbilityChargeRestoreTime": 1,
+            "cast_range_scepter_bonus": 1,
+            "lifetime": 1
+        },
+        "techies_minefield_sign": {
+            "aura_radius": 1,
+            "lifetime": 1
+        },
+        "techies_sticky_bomb": {
+            "acceleration": 1,
+            "duration": 1,
+            "pre_chase_time": 1,
+            "secondary_slow_duration": 1,
+            "speed": 1
+        },
+        "templar_assassin_psionic_trap": {
+            "movement_speed_max": 1,
+            "movement_speed_min": 1,
+            "shard_bonus_vision": 1,
+            "shard_max_silence_duration": 1,
+            "shard_min_silence_duration": 1,
+            "trap_bonus_damage": 1,
+            "trap_duration": 1,
+            "trap_max_charge_duration": 1,
+            "trap_radius": 1
+        },
+        "templar_assassin_refraction": {
+            "cast_while_disabled": 1
+        },
+        "templar_assassin_trap": {
+            "shard_bonus_max_traps": 1,
+            "trap_duration": 1
+        },
+        "templar_assassin_trap_teleport": {
+            "movement_speed_max": 1,
+            "movement_speed_min": 1,
+            "trap_bonus_damage": 1,
+            "trap_duration": 1,
+            "trap_max_charge_duration": 1,
+            "trap_radius": 1
+        },
+        "terrorblade_metamorphosis": {
+            "speed_loss": 1
+        },
+        "terrorblade_reflection": {
+            "illusion_outgoing_damage": 1
+        },
+        "tidehunter_anchor_smash": {
+            "targets_buildings": 1
+        },
+        "tidehunter_arm_of_the_deep": {
+            "duration_pct": 1
+        },
+        "tinker_heat_seeking_missile": {
+            "radius_explosion": 1,
+            "splash_pct": 1
+        },
+        "tinker_rearm": {
+            "AbilityChannelTime": 1
+        },
+        "tiny_grow": {
+            "attack_speed_reduction": 1
+        },
+        "tiny_toss": {
+            "AbilityCharges": 1,
+            "bonus_damage_pct": 1
+        },
+        "tiny_tree_channel": {
+            "abilitychanneltime": 1,
+            "bonus_damage": 1,
+            "interval": 1,
+            "range": 1
+        },
+        "tiny_tree_grab": {
+            "bat_increase": 1,
+            "speed_reduction": 1
+        },
+        "treant_eyes_in_the_forest": {
+            "overgrowth_aoe": 1,
+            "tree_respawn_seconds": 1,
+            "vision_aoe": 1
+        },
+        "treant_leech_seed": {
+            "projectile_speed": 1
+        },
+        "treant_natures_grasp": {
+            "creation_interval": 1,
+            "initial_latch_delay": 1,
+            "latch_range": 1,
+            "latch_vision": 1,
+            "vine_spawn_interval": 1
+        },
+        "treant_natures_guise": {
+            "shard_tree_movement_bonus_pct": 1
+        },
+        "treant_overgrowth": {
+            "purgable": 1
+        },
+        "troll_warlord_battle_trance": {
+            "scepter_duration_enemies": 1
+        },
+        "troll_warlord_berserkers_rage": {
+            "bonus_hp": 1,
+            "bonus_range": 1
+        },
+        "troll_warlord_whirling_axes_melee": {
+            "max_range": 1
+        },
+        "tusk_ice_shards": {
+            "shard_angle_step": 1,
+            "shard_count": 1,
+            "shard_distance": 1,
+            "shard_width": 1,
+            "turn_rate_slow": 1
+        },
+        "tusk_snowball": {
+            "snowball_grow_rate": 1,
+            "snowball_windup_radius": 1
+        },
+        "tusk_walrus_punch": {
+            "push_length": 1
+        },
+        "undying_decay": {
+            "str_scale_up": 1
+        },
+        "undying_tombstone": {
+            "tombstone_health": 1
+        },
+        "ursa_earthshock": {
+            "AbilityChargeRestoreTime": 1,
+            "AbilityDuration": 1,
+            "hop_duration": 1,
+            "hop_height": 1
+        },
+        "ursa_enrage": {
+            "cooldown_scepter": 1,
+            "damage_reduction": 1,
+            "duration": 1
+        },
+        "ursa_fury_swipes": {
+            "stun_duration": 1
+        },
+        "vengefulspirit_nether_swap": {
+            "damage_reduction": 1,
+            "scepter_charge_reduction": 1,
+            "scepter_radius": 1
+        },
+        "venomancer_poison_nova": {
+            "aspd_slow": 1
+        },
+        "venomancer_venomous_gale": {
+            "create_wards": 1,
+            "shard_ward_count": 1
+        },
+        "viper_nethertoxin": {
+            "projectile_speed": 1
+        },
+        "viper_poison_attack": {
+            "bonus_range": 1
+        },
+        "viper_viper_strike": {
+            "charge_restore_time": 1,
+            "max_charges": 1
+        },
+        "visage_grave_chill": {
+            "radius": 1
+        },
+        "visage_gravekeepers_cloak": {
+            "max_damage_reduction": 1,
+            "radius": 1
+        },
+        "void_spirit_aether_remnant": {
+            "end_radius": 1,
+            "projectile_speed": 1,
+            "pull_destination": 1,
+            "radius": 1,
+            "remnant_watch_radius": 1,
+            "start_radius": 1,
+            "think_interval": 1,
+            "watch_path_vision_radius": 1
+        },
+        "void_spirit_astral_step": {
+            "AbilityChargeRestoreTime": 1,
+            "AbilityCharges": 1,
+            "ability_chance_pct": 1,
+            "attack_chance_pct": 1,
+            "min_travel_distance": 1
+        },
+        "void_spirit_dissimilate": {
+            "destination_fx_radius": 1
+        },
+        "void_spirit_resonant_pulse": {
+            "return_projectile_speed": 1,
+            "speed": 1
+        },
+        "warlock_rain_of_chaos": {
+            "bounty_reduction_scepter": 1,
+            "hp_dmg_reduction_scepter": 1,
+            "number_of_golems_scepter": 1
+        },
+        "weaver_geminate_attack": {
+            "delay": 1
+        },
+        "weaver_shukuchi": {
+            "AbilityCharges": 1
+        },
+        "wildcard": {
+            "cooldown": 1,
+            "interval": 1,
+            "tooltip": 1
+        },
+        "windrunner_focusfire": {
+            "focusfire_fire_on_the_move": 1
+        },
+        "windrunner_shackleshot": {
+            "arrow_speed": 1,
+            "shackle_angle": 1,
+            "shackle_count": 1
+        },
+        "windrunner_windrun": {
+            "duration": 1
+        },
+        "winter_wyvern_arctic_burn": {
+            "tree_destruction_radius": 1
+        },
+        "winter_wyvern_splinter_blast": {
+            "projectile_max_time": 1,
+            "projectile_speed": 1,
+            "secondary_projectile_speed": 1
+        },
+        "winter_wyvern_winters_curse": {
+            "damage_amplification": 1,
+            "early_out_timer": 1
+        },
+        "wisp_spirits": {
+            "revolution_time": 1,
+            "spirit_amount": 1,
+            "spirit_duration": 1
+        },
+        "wisp_tether": {
+            "latch_distance": 1,
+            "radius": 1,
+            "self_bonus": 1
+        },
+        "witch_doctor_death_ward": {
+            "scepter_lifesteal": 1
+        },
+        "witch_doctor_maledict": {
+            "abilityduration": 1,
+            "bonus_damage_threshold": 1
+        },
+        "witch_doctor_paralyzing_cask": {
+            "bounce_delay": 1
+        },
+        "witch_doctor_voodoo_restoration": {
+            "enemy_damage_pct": 1,
+            "heal_interval": 1
+        },
+        "zuus_cloud": {
+            "cloud_duration": 1
+        },
+        "zuus_heavenly_jump": {
+            "hop_duration": 1,
+            "hop_height": 1
+        },
+        "zuus_lightning_bolt": {
+            "sight_duration": 1
+        },
+        "zuus_static_field": {
+            "damage_health_pct": 1
+        },
+        "zuus_thundergods_wrath": {
+            "sight_duration": 1
+        }
+    },
+    "limitlist": {
+        "abaddon_borrowed_time": {
+            "duration": {
+                "max": 250.0
+            },
+            "duration_scepter": {
+                "max": 250.0
+            }
+        },
+        "abyssal_underlord_atrophy_aura": {
+            "damage_reduction_pct": {
+                "max": 200.0
+            }
+        },
+        "abyssal_underlord_dark_portal": {
+            "damage_reduction": {
+                "max": 300.0
+            }
+        },
+        "bloodseeker_thirst": {
+            "invis_threshold_pct": {
+                "max": 200.0
+            },
+            "visibility_threshold_pct": {
+                "max": 200.0
+            }
+        },
+        "bounty_hunter_wind_walk": {
+            "damage_reduction_pct": {
+                "max": 300.0
+            }
+        },
+        "faceless_void_chronosphere": {
+            "duration": {
+                "max": 300.0
+            }
+        },
+        "generic_hidden": {
+            "duration": {
+                "max": 1.0,
+                "min": 1.0
+            }
+        },
+        "item_horrendous_halberd": {
+            "block_chance": {
+                "max": 1000.0
+            }
+        },
+        "item_misericorde": {
+            "missing_hp": {
+                "min": 10.0
+            }
+        },
+        "item_muertas_gun": {
+            "AbilityCastRange": {
+                "max": 200.0,
+                "min": 10.0
+            }
+        },
+        "item_titan_sliver": {
+            "status_resistance": {
+                "max": 900.0
+            }
+        },
+        "kunkka_ghostship": {
+            "ghostship_absorb": {
+                "max": 200.0
+            }
+        },
+        "kunkka_torrent_storm": {
+            "torrent_duration": {
+                "max": 420.0
+            }
+        },
+        "leshrac_pulse_nova": {
+            "damage_resistance": {
+                "max": 300.0
+            }
+        },
+        "luna_moon_glaive": {
+            "rotating_glaives_damage_reduction": {
+                "max": 400.0
+            }
+        },
+        "medusa_stone_gaze": {
+            "duration": {
+                "max": 500.0
+            },
+            "stone_duration": {
+                "max": 1000.0
+            }
+        },
+        "muerta_the_calling": {
+            "duration": {
+                "max": 300.0
+            },
+            "num_revenants": {
+                "max": 250.0
+            }
+        },
+        "naga_siren_song_of_the_siren": {
+            "duration": {
+                "max": 420.0
+            }
+        },
+        "necrolyte_heartstopper_aura": {
+            "heal_regen_to_damage": {
+                "max": 420.0
+            }
+        },
+        "nyx_assassin_burrow": {
+            "damage_reduction": {
+                "max": 200.0
+            }
+        },
+        "skeleton_king_reincarnation": {
+            "scepter_duration": {
+                "max": 420.0
+            }
+        },
+        "slardar_sprint": {
+            "puddle_status_resistance": {
+                "max": 225.0
+            }
+        },
+        "spectre_dispersion": {
+            "activation_duration": {
+                "max": 200.0
+            }
+        },
+        "spirit_breaker_bulldoze": {
+            "status_resistance": {
+                "max": 138.0
+            }
+        },
+        "tiny_avalanche": {
+            "tick_count": {
+                "min": 25.0
+            }
+        },
+        "troll_warlord_battle_trance": {
+            "trance_duration": {
+                "max": 420.0
+            }
+        },
+        "vengefulspirit_nether_swap": {
+            "damage_reduction": {
+                "max": 180.0
+            }
+        },
+        "wildcard": {
+            "linger_duration": {
+                "max": 420.0
+            }
+        },
+        "zuus_thundergods_wrath": {
+            "damage_pct": {
+                "max": 300.0
+            }
+        }
+    },
+    "nerflist": {
+        "abyssal_underlord_atrophy_aura": {
+            "ensnare_duration": 0.5
+        },
+        "abyssal_underlord_firestorm": {
+            "burn_damage": 0.25
+        },
+        "all": {
+            "area_of_effect": 0.2,
+            "attack_range_bonus": 0.2,
+            "bonus_attack_range": 0.2,
+            "interval": 0.2,
+            "radius": 0.2,
+            "sight_radius_day": 0.2,
+            "sight_radius_night": 0.2,
+            "splash_radius": 0.2,
+            "think_interval": 0.2,
+            "think_rate": 0.2,
+            "tick_interval": 0.2,
+            "tick_rate": 0.2,
+            "travel_distance": 0.2,
+            "true_sight_radius": 0.2
+        },
+        "ancient_apparition_ice_blast": {
+            "kill_pct": 0.4000000059604645
+        },
+        "ancient_apparition_ice_vortex": {
+            "vision_aoe": 0.2
+        },
+        "batrider_firefly": {
+            "bonus_vision": 0.2,
+            "tick_interval": 0.1
+        },
+        "bloodseeker_thirst": {
+            "invis_threshold_pct": 0.2
+        },
+        "bristleback_bristleback": {
+            "back_damage_reduction": 0.1,
+            "quill_release_threshold": 0.2,
+            "side_damage_reduction": 0.1
+        },
+        "crystal_maiden_freezing_field": {
+            "explosion_max_dist": 0.2,
+            "explosion_min_dist": 0.2
+        },
+        "dark_willow_bedlam": {
+            "attack_interval": 0.2,
+            "roaming_seconds_per_rotation": 0.2
+        },
+        "dazzle_shallow_grave": {
+            "duration": 0.1
+        },
+        "drow_ranger_wave_of_silence": {
+            "wave_length": 0.4000000059604645,
+            "wave_width": 0.2
+        },
+        "earth_spirit_magnetize": {
+            "damage_interval": 0.2
+        },
+        "earthshaker_aftershock": {
+            "aftershock_range": 0.2
+        },
+        "enigma_midnight_pulse": {
+            "damage_percent": 0.25
+        },
+        "faceless_void_chronosphere": {
+            "duration": 0.5
+        },
+        "fiend_grip_tick_interval": {
+            "kill_pct": 0.1
+        },
+        "furion_curse_of_the_forest": {
+            "range": 0.2
+        },
+        "furion_wrath_of_nature": {
+            "damage_percent_add": 0.2
+        },
+        "generic_hidden": {
+            "duration": 1.0
+        },
+        "grimstroke_ink_creature": {
+            "destroy_attacks": 0.2
+        },
+        "hoodwink_acorn_shot": {
+            "bounce_range": 0.2
+        },
+        "hoodwink_sharpshooter": {
+            "arrow_width": 0.2
+        },
+        "invoker_forge_spirit": {
+            "spirit_attack_range": 0.2
+        },
+        "invoker_sun_strike": {
+            "cataclysm_count": 0.25
+        },
+        "item_helm_of_the_undying": {
+            "duration": 0.3
+        },
+        "jakiro_macropyre": {
+            "linger_duration": 0.2
+        },
+        "juggernaut_blade_fury": {
+            "shard_attack_rate": 0.2
+        },
+        "keeper_of_the_light_will_o_wisp": {
+            "hit_count": 0.2
+        },
+        "kunkka_ghostship": {
+            "ghostship_absorb": 0.1,
+            "ghostship_distance": 0.2,
+            "ghostship_width": 0.2
+        },
+        "leshrac_split_earth": {
+            "shard_secondary_delay": 0.2
+        },
+        "lich_chain_frost": {
+            "jump_range": 0.2
+        },
+        "lich_frost_shield": {
+            "interval": 0.2
+        },
+        "lich_sinister_gaze": {
+            "aoe_scepter": 0.2,
+            "cast_range": 0.2
+        },
+        "life_stealer_infest": {
+            "attack_rate": 0.2
+        },
+        "life_stealer_open_wounds": {
+            "max_health_as_damage_pct": 0.2
+        },
+        "life_stealer_rage": {
+            "AbilityDuration": 0.2
+        },
+        "lina_dragon_slave": {
+            "dragon_slave_width_end": 0.2,
+            "dragon_slave_width_initial": 0.2
+        },
+        "lina_laguna_blade": {
+            "scepter_width": 0.2
+        },
+        "lina_light_strike_array": {
+            "light_strike_array_aoe": 0.2,
+            "light_strike_array_delay_time": 0.1
+        },
+        "lion_impale": {
+            "width": 0.2
+        },
+        "luna_moon_glaive": {
+            "range": 0.2
+        },
+        "magnataur_shockwave": {
+            "scepter_range": 0.2,
+            "scepter_width": 0.2,
+            "shock_width": 0.2
+        },
+        "mars_arena_of_blood": {
+            "spear_attack_interval": 0.2
+        },
+        "mars_bulwark": {
+            "physical_damage_reduction": 0.1,
+            "physical_damage_reduction_side": 0.1
+        },
+        "mars_spear": {
+            "spear_width": 0.2
+        },
+        "monkey_king_wukongs_command": {
+            "scepter_spawn_duration": 0.2,
+            "scepter_spawn_interval": 0.2
+        },
+        "morphling_waveform": {
+            "width": 0.2
+        },
+        "nevermore_necromastery": {
+            "necromastery_max_souls": 0.2,
+            "necromastery_max_souls_scepter": 0.2
+        },
+        "nyx_assassin_burrow": {
+            "damage_reduction": 0.2
+        },
+        "ogre_magi_bloodlust": {
+            "multicast_bloodlust_aoe": 0.5
+        },
+        "ogre_magi_ignite": {
+            "ignite_multicast_aoe": 0.2
+        },
+        "ogre_magi_smash": {
+            "multicast_fireshield_aoe": 0.5
+        },
+        "oracle_false_promise": {
+            "duration": 0.2
+        },
+        "phantom_assassin_fan_of_knives": {
+            "pct_health_damage_initial": 0.2
+        },
+        "puck_illusory_orb": {
+            "orb_vision": 0.2
+        },
+        "puck_phase_shift": {
+            "shard_attack_range_bonus": 0.5
+        },
+        "pugna_nether_blast": {
+            "structure_damage_mod": 0.2
+        },
+        "pugna_nether_ward": {
+            "shard_ward_bonus_cast_range": 0.2
+        },
+        "queenofpain_blink": {
+            "shard_aoe": 0.2,
+            "shard_duration": 0.2
+        },
+        "queenofpain_scream_of_pain": {
+            "area_of_effect": 0.2
+        },
+        "queenofpain_shadow_strike": {
+            "damage_interval": 0.2
+        },
+        "queenofpain_sonic_wave": {
+            "distance": 0.2,
+            "final_aoe": 0.2
+        },
+        "rattletrap_overclocking": {
+            "rocket_flare_rockets": 0.2
+        },
+        "razor_eye_of_the_storm": {
+            "strike_interval": 0.2
+        },
+        "rubick_arcane_supremacy": {
+            "cast_range": 0.25
+        },
+        "rubick_telekinesis": {
+            "max_land_distance": 0.2,
+            "shard_max_land_distance_bonus_pct": 0.2
+        },
+        "sandking_epicenter": {
+            "epicenter_radius": 0.2,
+            "shard_radius": 0.2
+        },
+        "sandking_sand_storm": {
+            "sand_storm_radius": 0.2
+        },
+        "shadow_demon_disseminate": {
+            "damage_reflection_pct": 0.2
+        },
+        "shadow_demon_shadow_poison": {
+            "radius": 0.2
+        },
+        "shadow_shaman_ether_shock": {
+            "end_distance": 0.2
+        },
+        "shadow_shaman_mass_serpent_ward": {
+            "ward_count": 0.5
+        },
+        "shadow_shaman_shackles": {
+            "shard_ward_count": 0.5,
+            "shard_ward_spawn_distance": 0.2
+        },
+        "silencer_glaives_of_wisdom": {
+            "permanent_int_steal_range": 0.2,
+            "shard_range": 0.2
+        },
+        "skywrath_mage_arcane_bolt": {
+            "scepter_radius": 0.2
+        },
+        "skywrath_mage_concussive_shot": {
+            "shot_vision": 0.2
+        },
+        "slark_shadow_dance": {
+            "duration": 0.2
+        },
+        "spectre_dispersion": {
+            "damage_reflection_pct": 0.1
+        },
+        "spirit_breaker_charge_of_darkness": {
+            "movement_speed": 0.5
+        },
+        "storm_spirit_ball_lightning": {
+            "ball_lightning_aoe": 0.2,
+            "ball_lightning_move_speed": 0.2,
+            "scepter_remnant_interval": 0.2
+        },
+        "storm_spirit_electric_vortex": {
+            "electric_vortex_pull_tether_range": 0.2
+        },
+        "storm_spirit_overload": {
+            "overload_aoe": 0.2
+        },
+        "techies_land_mines": {
+            "building_damage_pct": 0.25,
+            "mres_reduction": 0.25
+        },
+        "terrorblade_reflection": {
+            "range": 0.2
+        },
+        "tidehunter_arm_of_the_deep": {
+            "damage_pct": 0.2,
+            "range_pct": 0.2
+        },
+        "tidehunter_kraken_shell": {
+            "damage_cleanse": 0.2
+        },
+        "treant_leech_seed": {
+            "damage_interval": 0.2
+        },
+        "troll_warlord_whirling_axes_melee": {
+            "hit_radius": 0.2
+        },
+        "troll_warlord_whirling_axes_ranged": {
+            "axe_range": 0.2,
+            "axe_width": 0.2
+        },
+        "undying_tombstone": {
+            "zombie_interval": 0.2
+        },
+        "ursa_earthshock": {
+            "shard_enrage_duration": 0.1
+        },
+        "ursa_enrage": {
+            "status_resistance": 0.25
+        },
+        "vengefulspirit_wave_of_terror": {
+            "vision_aoe": 0.2,
+            "wave_width": 0.2
+        },
+        "viper_corrosive_skin": {
+            "effect_multiplier": 0.1
+        },
+        "viper_poison_attack": {
+            "shard_building_dmg_pct": 0.25
+        },
+        "void_spirit_astral_step": {
+            "max_travel_distance": 0.2
+        },
+        "warlock_fatal_bonds": {
+            "shard_aoe": 0.2,
+            "tick_interval": 0.2
+        },
+        "warlock_rain_of_chaos": {
+            "aoe": 0.2
+        },
+        "warlock_upheaval": {
+            "aoe": 0.2,
+            "tick_interval": 0.2
+        },
+        "warpine_raider_seed_shot": {
+            "bounce_range": 0.2
+        },
+        "weaver_the_swarm": {
+            "attack_rate": 0.1,
+            "destroy_attacks": 0.2
+        },
+        "wildcard": {
+            "_aoe": 0.2,
+            "distance": 0.2,
+            "radius": 0.2,
+            "range": 0.2
+        },
+        "windrunner_powershot": {
+            "arrow_range": 0.2
+        },
+        "winter_wyvern_arctic_burn": {
+            "attack_point": 0.2,
+            "night_vision_bonus": 0.2
+        },
+        "winter_wyvern_cold_embrace": {
+            "shard_splinter_range": 0.2
+        },
+        "witch_doctor_paralyzing_cask": {
+            "bounce_range": 0.2
+        },
+        "zuus_arc_lightning": {
+            "damage_health_pct": 0.25
+        },
+        "zuus_cloud": {
+            "cloud_bolt_interval": 0.2
+        },
+        "zuus_heavenly_jump": {
+            "range": 0.2
+        },
+        "zuus_lightning_bolt": {
+            "spread_aoe": 0.2
+        },
+        "zuus_thundergods_wrath": {
+            "damage": 0.3
+        }
+    },
+    "linklist":
+{
+    "faceless_void_time_walk":
+    {
+        "speed":
+        {
+            "faceless_void_time_walk_reverse.speed": "1"
+        }
+    },
+    "morphling_adaptive_strike_agi":
+    {
+        "projectile_speed":
+        {
+            "morphling_adaptive_strike_str.projectile_speed": "1"
+        }
+    },
+    "morphling_morph_agi":
+    {
+        "points_per_tick":
+        {
+            "morphling_morph_str.points_per_tick": "1"
+        },
+        "morph_cooldown":
+        {
+            "morphling_morph_str.morph_cooldown": "1"
+        },
+        "morph_rate_tooltip":
+        {
+            "morphling_morph_str.morph_rate_tooltip": "1"
+        },
+        "mana_cost":
+        {
+            "morphling_morph_str.mana_cost": "1"
+        },
+        "castable_while_stunned":
+        {
+            "morphling_morph_str.castable_while_stunned": "1"
+        }
+    },
+    "nevermore_shadowraze1":
+    {
+        "shadowraze_damage":
+        {
+            "nevermore_shadowraze2.shadowraze_damage": "1",
+            "nevermore_shadowraze3.shadowraze_damage": "1"
+        },
+        "shadowraze_radius":
+        {
+            "nevermore_shadowraze2.shadowraze_radius": "1",
+            "nevermore_shadowraze3.shadowraze_radius": "1"
+        },
+        "shadowraze_range":
+        {
+            "nevermore_shadowraze2.shadowraze_range": "1",
+            "nevermore_shadowraze3.shadowraze_range": "1"
+        },
+        "shadowraze_cooldown":
+        {
+            "nevermore_shadowraze2.shadowraze_cooldown": "1",
+            "nevermore_shadowraze3.shadowraze_cooldown": "1"
+        },
+        "stack_bonus_damage":
+        {
+            "nevermore_shadowraze2.stack_bonus_damage": "1",
+            "nevermore_shadowraze3.stack_bonus_damage": "1"
+        },
+        "duration":
+        {
+            "nevermore_shadowraze2.duration": "1",
+            "nevermore_shadowraze3.duration": "1"
+        },
+        "procs_attack":
+        {
+            "nevermore_shadowraze2.procs_attack": "1",
+            "nevermore_shadowraze3.procs_attack": "1"
+        },
+        "movement_speed_debuff":
+        {
+            "nevermore_shadowraze2.movement_speed_debuff": "1",
+            "nevermore_shadowraze3.movement_speed_debuff": "1"
+        },
+        "attack_speed_debuff":
+        {
+            "nevermore_shadowraze2.attack_speed_debuff": "1",
+            "nevermore_shadowraze3.attack_speed_debuff": "1"
+        },
+        "turn_rate_pct":
+        {
+            "nevermore_shadowraze2.turn_rate_pct": "1",
+            "nevermore_shadowraze3.turn_rate_pct": "1"
+        },
+        "cooldown_reduction_on_hero_hit":
+        {
+            "nevermore_shadowraze2.cooldown_reduction_on_hero_hit": "1",
+            "nevermore_shadowraze3.cooldown_reduction_on_hero_hit": "1"
+        }
+    },
+    "warlock_rain_of_chaos":
+    {
+        "golem_hp":
+        {
+            "warlock_rain_of_chaos.golem_hp_scepter": "1"
+        },
+        "golem_dmg":
+        {
+            "warlock_rain_of_chaos.golem_dmg_scepter": "1"
+        },
+        "golem_gold_bounty":
+        {
+            "warlock_rain_of_chaos.golem_gold_bounty_scepter": "1"
+        }
+    }
+}
+}

--- a/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boosted/lists.txt
+++ b/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boosted/lists.txt
@@ -2540,4 +2540,117 @@
         "damage"    "0.3"
     }
 }
+"linklist"
+{
+    "faceless_void_time_walk"
+    {
+        "speed"
+        {
+            "faceless_void_time_walk_reverse.speed" "1"
+        }
+    }
+    "morphling_adaptive_strike_agi"
+    {
+        "projectile_speed"
+        {
+            "morphling_adaptive_strike_str.projectile_speed" "1"
+        }
+    }
+    "morphling_morph_agi"
+    {
+        "points_per_tick"
+        {
+            "morphling_morph_str.points_per_tick" "1"
+        }
+        "morph_cooldown"
+        {
+            "morphling_morph_str.morph_cooldown" "1"
+        }
+        "morph_rate_tooltip"
+        {
+            "morphling_morph_str.morph_rate_tooltip" "1"
+        }
+        "mana_cost"
+        {
+            "morphling_morph_str.mana_cost" "1"
+        }
+        "castable_while_stunned"
+        {
+            "morphling_morph_str.castable_while_stunned" "1"
+        }
+    }
+    "nevermore_shadowraze1"
+    {
+        "shadowraze_damage"
+        {
+            "nevermore_shadowraze2.shadowraze_damage" "1"
+            "nevermore_shadowraze3.shadowraze_damage" "1"
+        }
+        "shadowraze_radius"
+        {
+            "nevermore_shadowraze2.shadowraze_radius" "1"
+            "nevermore_shadowraze3.shadowraze_radius" "1"
+        }
+        "shadowraze_range"
+        {
+            "nevermore_shadowraze2.shadowraze_range" "1"
+            "nevermore_shadowraze3.shadowraze_range" "1"
+        }
+        "shadowraze_cooldown"
+        {
+            "nevermore_shadowraze2.shadowraze_cooldown" "1"
+            "nevermore_shadowraze3.shadowraze_cooldown" "1"
+        }
+        "stack_bonus_damage"
+        {
+            "nevermore_shadowraze2.stack_bonus_damage" "1"
+            "nevermore_shadowraze3.stack_bonus_damage" "1"
+        }
+        "duration"
+        {
+            "nevermore_shadowraze2.duration" "1"
+            "nevermore_shadowraze3.duration" "1"
+        }
+        "procs_attack"
+        {
+            "nevermore_shadowraze2.procs_attack" "1"
+            "nevermore_shadowraze3.procs_attack" "1"
+        }
+        "movement_speed_debuff"
+        {
+            "nevermore_shadowraze2.movement_speed_debuff" "1"
+            "nevermore_shadowraze3.movement_speed_debuff" "1"
+        }
+        "attack_speed_debuff"
+        {
+            "nevermore_shadowraze2.attack_speed_debuff" "1"
+            "nevermore_shadowraze3.attack_speed_debuff" "1"
+        }
+        "turn_rate_pct"
+        {
+            "nevermore_shadowraze2.turn_rate_pct" "1"
+            "nevermore_shadowraze3.turn_rate_pct" "1"
+        }
+        "cooldown_reduction_on_hero_hit"
+        {
+            "nevermore_shadowraze2.cooldown_reduction_on_hero_hit" "1"
+            "nevermore_shadowraze3.cooldown_reduction_on_hero_hit" "1"
+        }
+    }
+    "warlock_rain_of_chaos"
+    {
+        "golem_hp"
+        {
+            "warlock_rain_of_chaos.golem_hp_scepter" "1"
+        }
+        "golem_dmg"
+        {
+            "warlock_rain_of_chaos.golem_dmg_scepter" "1"
+        }
+        "golem_gold_bounty"
+        {
+            "warlock_rain_of_chaos.golem_gold_bounty_scepter" "1"
+        }
+    }
+}
 }

--- a/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boosted/plugin.lua
+++ b/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boosted/plugin.lua
@@ -13,6 +13,7 @@ BoostedPlugin.newdawn_comp_url = "http://drteaspoon.fi:3000/list/newdawn_comp"
 BoostedPlugin.all_url = "http://drteaspoon.fi:3000/list/all"
 BoostedPlugin.none_url = "https://pastebin.com/raw/JQQQeQCR"
 BoostedPlugin.kv_bans = {}
+BoostedPlugin.linked_kv_bans = {} -- stores kvs that are linked and should not show as offers
 
 BoostedPlugin.player_boosters = {}
 
@@ -44,6 +45,8 @@ function BoostedPlugin:ApplySettings()
     else
         BoostedPlugin.kv_lists = {}
     end
+    print("BoostedPlugin:ApplySettings")
+    DeepPrintTable(BoostedPlugin.kv_lists)
     if BoostedPlugin.settings.base_list == "post_crownfall" then
         BoostedPlugin.official_url = BoostedPlugin.newdawn_url
     elseif BoostedPlugin.settings.base_list == "post_crownfall_comp" then
@@ -160,6 +163,15 @@ function BoostedPlugin:ApplyOnlineList(json,patch)
             BoostedPlugin.kv_lists.limitlist = Toolbox:PatchTable(BoostedPlugin.kv_lists.limitlist,data.limitlist)
         end
     end
+    if data.linklist == nil or type(data.linklist) ~= "table" or (next(data.linklist) == nil) then
+        print("link list empty")
+    else
+        if not patch or BoostedPlugin.kv_lists.linklist == nil or next(BoostedPlugin.kv_lists.linklist) == nil then
+            BoostedPlugin.kv_lists.linklist = data.linklist
+        else
+            BoostedPlugin.kv_lists.linklist = Toolbox:PatchTable(BoostedPlugin.kv_lists.linklist,data.linklist)
+        end
+    end
     if type(BoostedPlugin.kv_lists.blocklist) ~= "table" then 
         BoostedPlugin.kv_lists.blocklist = {
             all = {},
@@ -178,7 +190,42 @@ function BoostedPlugin:ApplyOnlineList(json,patch)
             wildcard = {}
         }
     end
+
+    if type(BoostedPlugin.kv_lists.linklist) ~= "table" then
+        print("link list set to empty")
+        BoostedPlugin.kv_lists.linklist = {
+            all = {},
+            wildcard = {}
+        }
+    end
+
+    BoostedPlugin:AutoblockLinkedKVs()
     return true
+end
+
+-- All linked kvs are put in a list to prevent them showing up as offers
+function BoostedPlugin:AutoblockLinkedKVs()
+    for sAbility, sAbilityValues in pairs(BoostedPlugin.kv_lists.linklist) do
+        for sKey, sKeyValues in pairs(sAbilityValues) do
+            for sKeyLinked, sKeyLinkedEnabled in pairs(sKeyValues) do
+                if sKeyLinkedEnabled == 1 then
+                    targetAbility, targetKey = sKeyLinked:match("([^.]+)[.]([^.]+)")
+                    if type(BoostedPlugin.linked_kv_bans[targetAbility]) ~= "table" then
+                        BoostedPlugin.linked_kv_bans[targetAbility] = {}
+                    end
+                    BoostedPlugin.linked_kv_bans[targetAbility][targetKey] = 1
+                end
+            end
+        end
+    end
+end
+
+-- Checks if the kv is blocked due to being linked
+function BoostedPlugin:IsNotBlockedByLinkedKV(ability, key)
+    if BoostedPlugin.linked_kv_bans == nil then return true end
+    if BoostedPlugin.linked_kv_bans[ability] == nil then return true end
+    if BoostedPlugin.linked_kv_bans[ability][key] == nil then return true end
+    return false
 end
 
 
@@ -503,6 +550,33 @@ function BoostedPlugin:boost_player(tEvent)
             end
         end
         hUnit = Entities:Next(hUnit)
+    end
+
+    -- process linked kvs
+    BoostedPlugin:TriggerLinkedKVs(tEvent)
+end
+
+-- checks if this should trigger linked kv updates and then generates events to do so
+function BoostedPlugin:TriggerLinkedKVs(tEvent)
+    local sAbility = tEvent.ability
+    local sKey = tEvent.key
+
+    if tEvent.is_linked == true then return end
+    if BoostedPlugin.kv_lists.linklist == nil then return end
+    if BoostedPlugin.kv_lists.linklist[sAbility] == nil then return end
+    if BoostedPlugin.kv_lists.linklist[sAbility][sKey] == nil then return end
+
+    -- add a link flag so that we don't wind up in an infinite loop or something due to nesting
+    tEvent.is_linked = true
+    for sKeyLinked, sKeyLinkedEnabled in pairs(BoostedPlugin.kv_lists.linklist[sAbility][sKey]) do
+        if sKeyLinkedEnabled == 1 then
+            targetAbility, targetKey = sKeyLinked:match("([^.]+)[.]([^.]+)")
+            tEvent.ability = targetAbility
+            tEvent.key = targetKey
+            -- print("[BoostedPlugin:TriggerLinkedKVs] will trigger" .. targetAbility .. " " .. targetKey)
+            DeepPrintTable(tEvent)
+            BoostedPlugin:boost_player(tEvent)
+        end
     end
 end
 
@@ -1174,7 +1248,7 @@ function BoostedPlugin:IntoRng(ability,t,iPlayer,hAbility)
     end
     for k,v in pairs(t) do
 		if v ~= nil then
-            if BoostedPlugin.kv_bans[iPlayer][ability .. "&" .. k] == nil then
+            if BoostedPlugin.kv_bans[iPlayer][ability .. "&" .. k] == nil and BoostedPlugin:IsNotBlockedByLinkedKV(ability, k) then
                 local flBaseValue = hAbility:GetLevelSpecialValueNoOverride( k, nSpecialLevel )
                 if not (flBaseValue < 0.001 and flBaseValue > -0.001) then
                     table.insert(ti,k)

--- a/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boosted/plugin.lua
+++ b/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boosted/plugin.lua
@@ -45,8 +45,6 @@ function BoostedPlugin:ApplySettings()
     else
         BoostedPlugin.kv_lists = {}
     end
-    print("BoostedPlugin:ApplySettings")
-    DeepPrintTable(BoostedPlugin.kv_lists)
     if BoostedPlugin.settings.base_list == "post_crownfall" then
         BoostedPlugin.official_url = BoostedPlugin.newdawn_url
     elseif BoostedPlugin.settings.base_list == "post_crownfall_comp" then
@@ -574,7 +572,6 @@ function BoostedPlugin:TriggerLinkedKVs(tEvent)
             tEvent.ability = targetAbility
             tEvent.key = targetKey
             -- print("[BoostedPlugin:TriggerLinkedKVs] will trigger" .. targetAbility .. " " .. targetKey)
-            DeepPrintTable(tEvent)
             BoostedPlugin:boost_player(tEvent)
         end
     end


### PR DESCRIPTION
This PR adds a section to the kvs called "linklist", where you can connect two kvs to each other, for example:
`    "nevermore_shadowraze1"
    {
        "shadowraze_damage"
        {
            "nevermore_shadowraze2.shadowraze_damage" "1"
            "nevermore_shadowraze3.shadowraze_damage" "1"
        }
}`
This makes it so changes to shadowraze1's damage also apply to shadowraze2 and shadowraze3.

Furthermore, this automatically hides the linked kvs so that they will not receive them as offers (in the example above, you would only ever see shadowraze1's damage as an offer, never 2 or 3).