### PR TITLE
add boost scaling and boost commands

### DIFF
--- a/game/dota_addons/mgmod/resource/addon_english.txt
+++ b/game/dota_addons/mgmod/resource/addon_english.txt
@@ -290,6 +290,13 @@
 		"Plugin_tower_buffs_Option_bonus_magic_resistance"	"Bonus Magic Resistance"
 		"Plugin_tower_buffs_Option_unyielding_shield"	"Unyielding Shield"
 
+		//Boost scaling
+		"Plugin_boost_scaling" "Boost Scaling"
+		"Plugin_boost_scaling_Option_tower_bonus_hp" "Tower Bonus Health per Boost"
+		"Plugin_boost_scaling_Option_tower_bonus_hp_regen"	"Tower Bonus Health Regen"
+		"Plugin_boost_scaling_Option_tower_bonus_damage"	"Tower Bonus Damage"
+		"Plugin_boost_scaling_Option_tower_bonus_armor"	"Tower Bonus Armor"
+		"Plugin_boost_scaling_Option_tower_bonus_magic_resistance"	"Tower Bonus Magic Resistance"
 
 		"Plugin_basic_commands" "Basic Chat Commands"
 		"Plugin_basic_commands_Option_min_diff" "Minimum kills behind for -gg"

--- a/game/dota_addons/mgmod/resource/addon_russian.txt
+++ b/game/dota_addons/mgmod/resource/addon_russian.txt
@@ -265,7 +265,14 @@
         "Plugin_tower_buffs_Option_bonus_armor" "Дополнительная броня"
         "Plugin_tower_buffs_Option_bonus_magic_resistance" "Дополнительное сопротивление магии"
         "Plugin_tower_buffs_Option_unyielding_shield" "Неуступчивый щит"
-
+        
+		//Boost scaling
+		"Plugin_boost_scaling" "Boost Scaling"
+		"Plugin_boost_scaling_Option_tower_bonus_hp" "Tower Bonus Health per Boost"
+		"Plugin_boost_scaling_Option_tower_bonus_hp_regen"	"Tower Bonus Health Regen"
+		"Plugin_boost_scaling_Option_tower_bonus_damage"	"Tower Bonus Damage"
+		"Plugin_boost_scaling_Option_tower_bonus_armor"	"Tower Bonus Armor"
+		"Plugin_boost_scaling_Option_tower_bonus_magic_resistance"	"Tower Bonus Magic Resistance"
 
         // Основные чат-команды
         "Plugin_basic_commands" "Основные чат-команды"

--- a/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins.txt
+++ b/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins.txt
@@ -34,6 +34,7 @@
 #base "plugins/boosted/plugin.txt"
 #base "plugins/time_scaling/plugin.txt"
 #base "plugins/tower_buffs/plugin.txt"
+#base "plugins/boost_scaling/plugin.txt"
 #base "plugins/thanksihateit/plugin.txt"
 #base "plugins/items_x/plugin.txt"
 #base "plugins/xmas_2023/plugin.txt"

--- a/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boost_scaling/Readme.md
+++ b/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boost_scaling/Readme.md
@@ -1,0 +1,2 @@
+# Tower Boost Scaling
+Stuff to buff towers based on when boosts happen.

--- a/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boost_scaling/boost_scaling_bonus_armor.lua
+++ b/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boost_scaling/boost_scaling_bonus_armor.lua
@@ -1,0 +1,26 @@
+boost_scaling_bonus_armor = boost_scaling_bonus_armor or class({})
+
+
+function boost_scaling_bonus_armor:GetTexture() return "backdoor_protection" end
+
+function boost_scaling_bonus_armor:IsPermanent() return true end
+function boost_scaling_bonus_armor:RemoveOnDeath() return false end
+function boost_scaling_bonus_armor:IsHidden() return true end
+function boost_scaling_bonus_armor:IsDebuff() return false end
+function boost_scaling_bonus_armor:IsPurgeException() return false end
+function boost_scaling_bonus_armor:AllowIllusionDuplicate() return false end
+
+function boost_scaling_bonus_armor:GetAttributes()
+	return MODIFIER_ATTRIBUTE_PERMANENT + MODIFIER_ATTRIBUTE_IGNORE_INVULNERABLE
+end
+
+function boost_scaling_bonus_armor:DeclareFunctions()
+	local funcs = {
+        MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS
+	}
+	return funcs
+end
+
+function boost_scaling_bonus_armor:GetModifierPhysicalArmorBonus()
+    return self:GetStackCount()
+end

--- a/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boost_scaling/boost_scaling_bonus_damage.lua
+++ b/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boost_scaling/boost_scaling_bonus_damage.lua
@@ -1,0 +1,26 @@
+boost_scaling_bonus_damage = boost_scaling_bonus_damage or class({})
+
+
+function boost_scaling_bonus_damage:GetTexture() return "backdoor_protection" end
+
+function boost_scaling_bonus_damage:IsPermanent() return true end
+function boost_scaling_bonus_damage:RemoveOnDeath() return false end
+function boost_scaling_bonus_damage:IsHidden() return true end
+function boost_scaling_bonus_damage:IsDebuff() return false end
+function boost_scaling_bonus_damage:IsPurgeException() return false end
+function boost_scaling_bonus_damage:AllowIllusionDuplicate() return false end
+
+function boost_scaling_bonus_damage:GetAttributes()
+	return MODIFIER_ATTRIBUTE_PERMANENT + MODIFIER_ATTRIBUTE_IGNORE_INVULNERABLE
+end
+
+function boost_scaling_bonus_damage:DeclareFunctions()
+	local funcs = {
+        MODIFIER_PROPERTY_BASEATTACK_BONUSDAMAGE
+	}
+	return funcs
+end
+
+function boost_scaling_bonus_damage:GetModifierBaseAttack_BonusDamage()
+    return self:GetStackCount()
+end

--- a/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boost_scaling/boost_scaling_bonus_hp.lua
+++ b/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boost_scaling/boost_scaling_bonus_hp.lua
@@ -1,0 +1,26 @@
+boost_scaling_bonus_hp = boost_scaling_bonus_hp or class({})
+
+
+function boost_scaling_bonus_hp:GetTexture() return "backdoor_protection" end
+
+function boost_scaling_bonus_hp:IsPermanent() return true end
+function boost_scaling_bonus_hp:RemoveOnDeath() return false end
+function boost_scaling_bonus_hp:IsHidden() return true end
+function boost_scaling_bonus_hp:IsDebuff() return false end
+function boost_scaling_bonus_hp:IsPurgeException() return false end
+function boost_scaling_bonus_hp:AllowIllusionDuplicate() return false end
+
+function boost_scaling_bonus_hp:GetAttributes()
+	return MODIFIER_ATTRIBUTE_PERMANENT + MODIFIER_ATTRIBUTE_IGNORE_INVULNERABLE
+end
+
+function boost_scaling_bonus_hp:DeclareFunctions()
+	local funcs = {
+        MODIFIER_PROPERTY_EXTRA_HEALTH_BONUS 
+	}
+	return funcs
+end
+
+function boost_scaling_bonus_hp:GetModifierExtraHealthBonus()
+    return self:GetStackCount()
+end

--- a/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boost_scaling/boost_scaling_bonus_hp_regen.lua
+++ b/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boost_scaling/boost_scaling_bonus_hp_regen.lua
@@ -1,0 +1,26 @@
+boost_scaling_bonus_hp_regen = boost_scaling_bonus_hp_regen or class({})
+
+
+function boost_scaling_bonus_hp_regen:GetTexture() return "backdoor_protection" end
+
+function boost_scaling_bonus_hp_regen:IsPermanent() return true end
+function boost_scaling_bonus_hp_regen:RemoveOnDeath() return false end
+function boost_scaling_bonus_hp_regen:IsHidden() return true end
+function boost_scaling_bonus_hp_regen:IsDebuff() return false end
+function boost_scaling_bonus_hp_regen:IsPurgeException() return false end
+function boost_scaling_bonus_hp_regen:AllowIllusionDuplicate() return false end
+
+function boost_scaling_bonus_hp_regen:GetAttributes()
+	return MODIFIER_ATTRIBUTE_PERMANENT + MODIFIER_ATTRIBUTE_IGNORE_INVULNERABLE
+end
+
+function boost_scaling_bonus_hp_regen:DeclareFunctions()
+	local funcs = {
+        MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT
+	}
+	return funcs
+end
+
+function boost_scaling_bonus_hp_regen:GetModifierConstantHealthRegen()
+    return self:GetStackCount()
+end

--- a/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boost_scaling/boost_scaling_bonus_magic_resistance.lua
+++ b/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boost_scaling/boost_scaling_bonus_magic_resistance.lua
@@ -1,0 +1,26 @@
+boost_scaling_bonus_magic_resistance = boost_scaling_bonus_magic_resistance or class({})
+
+
+function boost_scaling_bonus_magic_resistance:GetTexture() return "backdoor_protection" end
+
+function boost_scaling_bonus_magic_resistance:IsPermanent() return true end
+function boost_scaling_bonus_magic_resistance:RemoveOnDeath() return false end
+function boost_scaling_bonus_magic_resistance:IsHidden() return true end
+function boost_scaling_bonus_magic_resistance:IsDebuff() return false end
+function boost_scaling_bonus_magic_resistance:IsPurgeException() return false end
+function boost_scaling_bonus_magic_resistance:AllowIllusionDuplicate() return false end
+
+function boost_scaling_bonus_magic_resistance:GetAttributes()
+	return MODIFIER_ATTRIBUTE_PERMANENT + MODIFIER_ATTRIBUTE_IGNORE_INVULNERABLE
+end
+
+function boost_scaling_bonus_magic_resistance:DeclareFunctions()
+	local funcs = {
+        MODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS
+	}
+	return funcs
+end
+
+function boost_scaling_bonus_magic_resistance:GetModifierMagicalResistanceBonus()
+    return self:GetStackCount()
+end

--- a/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boost_scaling/plugin.lua
+++ b/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boost_scaling/plugin.lua
@@ -1,0 +1,81 @@
+BoostScalingPlugin = class({})
+_G.BoostScalingPlugin = BoostScalingPlugin
+BoostScalingPlugin.settings = {}
+BoostScalingPlugin.unit_cache = {}
+
+function BoostScalingPlugin:Init()
+    print("[BoostScalingPlugin] found")
+end
+
+function BoostScalingPlugin:ApplySettings()
+    BoostScalingPlugin.settings = PluginSystem:GetAllSetting("boost_scaling")
+    LinkLuaModifier("boost_scaling_bonus_hp", "plugin_system/plugins/boost_scaling/boost_scaling_bonus_hp.lua", LUA_MODIFIER_MOTION_NONE)
+    LinkLuaModifier("boost_scaling_bonus_hp_regen", "plugin_system/plugins/boost_scaling/boost_scaling_bonus_hp_regen.lua", LUA_MODIFIER_MOTION_NONE)
+    LinkLuaModifier("boost_scaling_bonus_damage", "plugin_system/plugins/boost_scaling/boost_scaling_bonus_damage.lua", LUA_MODIFIER_MOTION_NONE)
+    LinkLuaModifier("boost_scaling_bonus_armor", "plugin_system/plugins/boost_scaling/boost_scaling_bonus_armor.lua", LUA_MODIFIER_MOTION_NONE)
+    LinkLuaModifier("boost_scaling_bonus_magic_resistance", "plugin_system/plugins/boost_scaling/boost_scaling_bonus_magic_resistance.lua", LUA_MODIFIER_MOTION_NONE)
+    for _, building in pairs(Toolbox:AllTowers()) do
+        if BoostScalingPlugin.settings.tower_bonus_hp > 0 then
+            building:AddNewModifier(building, nil, "boost_scaling_bonus_hp", {})
+        end
+        if BoostScalingPlugin.settings.tower_bonus_hp_regen > 0 then
+            building:AddNewModifier(building, nil, "boost_scaling_bonus_hp_regen", {})
+        end
+        if BoostScalingPlugin.settings.tower_bonus_damage > 0 then
+            building:AddNewModifier(building, nil, "boost_scaling_bonus_damage", {})
+        end
+        if BoostScalingPlugin.settings.tower_bonus_armor > 0 then
+            building:AddNewModifier(building, nil, "boost_scaling_bonus_armor", {})
+        end
+
+        if BoostScalingPlugin.settings.tower_bonus_magic_resistance > 0 then
+            building:AddNewModifier(building, nil, "boost_scaling_bonus_magic_resistance", {})
+        end
+    end
+
+    PluginSystem:InternalEvent_Register("boost_grant_all",function()
+        BoostScalingPlugin:BoostTowersAll()
+    end)
+
+    PluginSystem:InternalEvent_Register("boost_grant_team",function(event)
+        DeepPrintTable(event)
+        BoostScalingPlugin:BoostTowersTeam(event.team)
+    end)
+end
+
+function BoostScalingPlugin:BoostTowersAll()
+    for _, building in pairs(Toolbox:AllTowers()) do
+        BoostScalingPlugin:BoostTower(building)
+    end
+end
+
+function BoostScalingPlugin:BoostTowersTeam(iTeam)
+    for _, building in pairs(Toolbox:AllTowers()) do
+        if building:GetTeam() == iTeam then
+            BoostScalingPlugin:BoostTower(building)
+        end
+    end
+end
+
+function BoostScalingPlugin:BoostTower(tower)
+    if BoostScalingPlugin.settings.tower_bonus_hp > 0 then
+        local hMod = tower:FindAllModifiersByName("boost_scaling_bonus_hp")[1]
+        if hMod ~= nil then hMod:SetStackCount(hMod:GetStackCount() + BoostScalingPlugin.settings.tower_bonus_hp) end
+    end
+    if BoostScalingPlugin.settings.tower_bonus_hp_regen > 0 then
+        local hMod = tower:FindAllModifiersByName("boost_scaling_bonus_hp_regen")[1]
+        if hMod ~= nil then hMod:SetStackCount(hMod:GetStackCount() + BoostScalingPlugin.settings.tower_bonus_hp_regen) end
+    end
+    if BoostScalingPlugin.settings.tower_bonus_damage > 0 then
+        local hMod = tower:FindAllModifiersByName("boost_scaling_bonus_damage")[1]
+        if hMod ~= nil then hMod:SetStackCount(hMod:GetStackCount() + BoostScalingPlugin.settings.tower_bonus_damage) end
+    end
+    if BoostScalingPlugin.settings.tower_bonus_armor > 0 then
+        local hMod = tower:FindAllModifiersByName("boost_scaling_bonus_armor")[1]
+        if hMod ~= nil then hMod:SetStackCount(hMod:GetStackCount() + BoostScalingPlugin.settings.tower_bonus_armor) end
+    end
+    if BoostScalingPlugin.settings.tower_bonus_magic_resistance > 0 then
+        local hMod = tower:FindAllModifiersByName("boost_scaling_bonus_magic_resistance")[1]
+        if hMod ~= nil then hMod:SetStackCount(hMod:GetStackCount() + BoostScalingPlugin.settings.tower_bonus_magic_resistance) end
+    end
+end

--- a/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boost_scaling/plugin.txt
+++ b/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boost_scaling/plugin.txt
@@ -1,0 +1,10 @@
+"Plugins"
+{
+    "boost_scaling" {
+        "MainClass" "BoostScalingPlugin"
+        "InitFunction" "Init"
+        "StateRegistrations" {
+            "ApplySettings" "DOTA_GAMERULES_STATE_HERO_SELECTION"
+        }
+    }
+}

--- a/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boost_scaling/settings.txt
+++ b/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boost_scaling/settings.txt
@@ -1,0 +1,35 @@
+"plugin_settings"
+{
+    "Order" "96"
+    "enabled" {
+        "TYPE" "boolean"
+        "DEFAULT" "0"
+    }
+    "tower_bonus_hp" {
+        "Order" "2"
+        "TYPE" "number"
+        "DEFAULT" "0"
+    }
+    "tower_bonus_hp_regen" {
+        "Order" "3"
+        "TYPE" "number"
+        "DEFAULT" "0"
+    }
+    "tower_bonus_damage" {
+        "Order" "4"
+        "TYPE" "number"
+        "DEFAULT" "0"
+    }
+    "tower_bonus_armor" {
+        "Order" "5"
+        "TYPE" "number"
+        "DEFAULT" "0"
+    }
+// towers aparently cant have magic resistance :/
+    "tower_bonus_magic_resistance" {
+        "Order" "6"
+        "TYPE" "number"
+        "UNIT" "%"
+        "DEFAULT" "0"
+    }
+}

--- a/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boosted/plugin.lua
+++ b/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boosted/plugin.lua
@@ -1298,6 +1298,8 @@ function BoostedPlugin:GrantAllUpgrade()
             end
         end
     end
+
+    PluginSystem:InternalEvent_Call("boost_grant_all")
 end
 
 function BoostedPlugin:GrantTeamUpgrade(iTeam)
@@ -1312,6 +1314,10 @@ function BoostedPlugin:GrantTeamUpgrade(iTeam)
             end
         end
     end
+
+    PluginSystem:InternalEvent_Call("boost_grant_team", {
+        team = iTeam
+    })
 end
 
 function BoostedPlugin:GrantPlayerUpgrade(iPlayer)
@@ -1510,6 +1516,77 @@ function BoostedPlugin:FixMe(tArgs,bTeam,iPlayer)
                     end
                 end
             end
+        end
+    end
+end
+
+function BoostedPlugin:AddBoostCommand(tArgs,bTeam,iPlayer)
+    if GameRules:IsCheatMode() then
+        print("[BoostedPlugin:AddBoostCommand] AddBoost " .. iPlayer)
+        tEvent = {
+            PlayerID = iPlayer,
+            ability = tArgs[2],
+            key = tArgs[3],
+            rarity = tArgs[4],
+            value = tArgs[5]
+        }
+        BoostedPlugin:boost_player(tEvent)
+    end
+end
+
+function BoostedPlugin:ClearBoostsCommand(tArgs,bTeam,iPlayer)
+    if GameRules:IsCheatMode() then
+        print("[BoostedPlugin:ClearBoostsCommand] ClearBoosts " .. iPlayer)
+
+        for sAbility,hAbility in pairs(BoostedPlugin.lists[iPlayer]) do
+            for sKey, value in pairs(hAbility) do
+                if value ~= 1 then
+                    local tEvent = {
+                        PlayerID = iPlayer,
+                        ability = sAbility,
+                        key = sKey,
+                        rarity = 1,
+                        value = 1,
+                        is_linked = 1 -- for this we don't want to trigger linked because we'll be handling them ourselves
+                    }
+                    if value > 1.00001 then
+                        tEvent.value = -1
+                    end
+    
+                    BoostedPlugin:boost_player(tEvent) 
+                end
+            end
+        end
+    end
+end
+
+function BoostedPlugin:GrantOfferCommand(tArgs,bTeam,iPlayer)
+    if GameRules:IsCheatMode() then
+        local amount = tArgs[2]
+        if amount == nil then
+            amount = 1
+        else
+            amount = tonumber(amount)
+        end
+        print("[BoostedPlugin:GrantOfferCommand] GrantOffer " .. iPlayer .. " " .. amount)
+        for i=1,amount do
+            BoostedPlugin:GrantPlayerUpgrade(iPlayer)
+        end
+    end
+end
+
+function BoostedPlugin:GrantTeamOfferCommand(tArgs,bTeam,iPlayer)
+    if GameRules:IsCheatMode() then
+        local amount = tArgs[2]
+        if amount == nil then
+            amount = 1
+        else
+            amount = tonumber(amount)
+        end
+        local iTeam = PlayerResource:GetTeam(iPlayer)
+        print("[BoostedPlugin:GrantTeamOfferCommand] GrantTeamOffer " .. iTeam .. " " .. amount)
+        for i=1,amount do
+            BoostedPlugin:GrantTeamUpgrade(iTeam)
         end
     end
 end

--- a/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boosted/plugin.txt
+++ b/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/boosted/plugin.txt
@@ -12,6 +12,10 @@
         }
         "CmdRegistrations" {
             "-fixme" "FixMe"
+            "-addboosts" "AddBoostCommand"
+            "-clearboosts" "ClearBoostsCommand"
+            "-selfboost" "GrantOfferCommand"
+            "-teamboost" "GrantTeamOfferCommand"
         }
         "ConflictTags" "special_override"
     }


### PR DESCRIPTION
This adds two features:

1. Boosted chat commands for helping fehren do tests (i.e. investigating broken or overpowered kvs).

The commands for testing (only work with cheats enabled) are:
-addboosts morphling_morph_agi points_per_tick 3 1
    Adds a specific boost to the player. Arguments are: ability, kv, rarity (1,2,3), direction (1 or -1)
-clearboosts
   Removes all boosts from the player. This will refund using normal refund rules.
-selfboost X
   Grants the player X number of boosts via the standard offers.
-teamboost X
   Grants the entire team of the player X number of boosts via the standard offers. This is necessary to trigger the tower boost.

2. The "Boost scaling" plugin
This plugin listens to the new events triggered by boosted, applying a buff to the towers whenever their respective teams gain a boost. This buff stacks and lasts forever and is configurable.