### PR TITLE
add currency gain on hero kill based

### DIFF
--- a/game/dota_addons/mgmod/resource/addon_english.txt
+++ b/game/dota_addons/mgmod/resource/addon_english.txt
@@ -797,6 +797,9 @@
 		"Plugin_currencies_Option_hero_kill_reward_amount" "Hero Kill Reward Amount"
 		"Plugin_currencies_Option_hero_kill_reward_amount_Description" "Last hitting enemy hero grants currency. 0 or less disables the feature."
 		
+		"Plugin_currencies_Option_hero_kill_reward_bounty" "Hero Kill Reward Bounty"
+		"Plugin_currencies_Option_hero_kill_reward_bounty_Description" "Last hitting enemy hero grants currency as percentage of their bounty. 0 or less disables the feature."
+		
 		"Plugin_currencies_Option_observer_kill_reward_currency" "Observer Kill Reward Type"
 		"Plugin_currencies_Option_observer_kill_reward_currency_Drop_red" "Red"
 		"Plugin_currencies_Option_observer_kill_reward_currency_Drop_green" "Green"

--- a/game/dota_addons/mgmod/resource/addon_russian.txt
+++ b/game/dota_addons/mgmod/resource/addon_russian.txt
@@ -671,6 +671,9 @@
         "Plugin_currencies_Option_hero_kill_reward_amount" "Количество валюты за убийство героя"
         "Plugin_currencies_Option_hero_kill_reward_amount_Description" "Последнее попадание по вражескому герою дает валюту. 0 или меньше отключает эту функцию."
 
+        "Plugin_currencies_Option_hero_kill_reward_bounty" "Hero Kill Reward Bounty"
+		"Plugin_currencies_Option_hero_kill_reward_bounty_Description" "Last hitting enemy hero grants currency as percentage of their bounty. 0 or less disables the feature."
+
         "Plugin_currencies_Option_observer_kill_reward_currency" "Тип вознаграждения за убийство наблюдателя"
         "Plugin_currencies_Option_observer_kill_reward_currency_Drop_red" "Красная"
         "Plugin_currencies_Option_observer_kill_reward_currency_Drop_green" "Зеленая"

--- a/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/currencies/plugin.txt
+++ b/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/currencies/plugin.txt
@@ -7,5 +7,8 @@
             "ApplySettings" "DOTA_GAMERULES_STATE_HERO_SELECTION"
             "StartRewards" "DOTA_GAMERULES_STATE_GAME_IN_PROGRESS"
         }
+        "FilterRegistrations" {
+            "ModifyGoldFilter" "ModifyGoldFilter"
+        }
     }
 }

--- a/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/currencies/rewards.lua
+++ b/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/currencies/rewards.lua
@@ -125,3 +125,22 @@ function CurrenciesPlugin:ChannelFinished(tEvent)
         end
     end
 end
+
+function CurrenciesPlugin:ModifyGoldFilter(tEvent)
+    if tEvent.gold == nil then
+        print("[CurrenciesPlugin] modify gold event is fucking up again.")
+    end
+    
+    if tEvent.reason_const == DOTA_ModifyGold_HeroKill and CurrenciesPlugin.settings.hero_kill_reward_bounty > 0 then
+        local iReward = math.floor(tEvent.gold * CurrenciesPlugin.settings.hero_kill_reward_bounty / 100)
+        if iReward > 0 then
+            CurrenciesPlugin:AlterCurrency(CurrenciesPlugin.settings.hero_kill_reward_currency,tEvent.player_id_const,iReward)
+            local iPlayer = PlayerResource:GetPlayer(tEvent.player_id_const)
+            local hUnit = iPlayer and iPlayer:GetAssignedHero()
+            if hUnit then
+                CurrenciesPlugin:ShowEarnParticle(iReward,hUnit,hUnit:GetTeam(),CurrenciesPlugin.settings.hero_kill_reward_currency)
+            end
+        end
+    end
+    return {true, tEvent}
+end

--- a/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/currencies/settings.txt
+++ b/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/currencies/settings.txt
@@ -115,12 +115,18 @@
     {
         "Order" "53"
         "TYPE" "number"
+        "DEFAULT" "0"
+    }
+    "hero_kill_reward_bounty"
+    {
+        "Order" "54"
+        "TYPE" "number"
         "DEFAULT" "25"
     }
     
     "observer_kill_reward_currency"
     {
-        "Order" "54"
+        "Order" "60"
         "TYPE" "dropdown"
         "DEFAULT" "red"
         "OPTIONS" {
@@ -132,14 +138,14 @@
     }
     "observer_kill_reward_amount"
     {
-        "Order" "55"
+        "Order" "61"
         "TYPE" "number"
         "DEFAULT" "25"
     }
     
     "observer_plant_reward_currency"
     {
-        "Order" "56"
+        "Order" "70"
         "TYPE" "dropdown"
         "DEFAULT" "red"
         "OPTIONS" {
@@ -151,14 +157,14 @@
     }
     "observer_plant_reward_amount"
     {
-        "Order" "57"
+        "Order" "71"
         "TYPE" "number"
         "DEFAULT" "50"
     }
     
     "timed_reward_currency"
     {
-        "Order" "58"
+        "Order" "80"
         "TYPE" "dropdown"
         "DEFAULT" "red"
         "OPTIONS" {
@@ -170,20 +176,20 @@
     }
     "timed_reward_amount"
     {
-        "Order" "59"
+        "Order" "81"
         "TYPE" "number"
         "DEFAULT" "100"
     }
     "timed_reward_rate"
     {
-        "Order" "60"
+        "Order" "82"
         "TYPE" "number"
         "DEFAULT" "60"
     }
     
     "tower_kill_reward_currency"
     {
-        "Order" "61"
+        "Order" "90"
         "TYPE" "dropdown"
         "DEFAULT" "red"
         "OPTIONS" {
@@ -196,14 +202,14 @@
 
     "tower_kill_reward_amount"
     {
-        "Order" "62"
+        "Order" "91"
         "TYPE" "number"
         "DEFAULT" "100"
     }
 
     "roshan_kill_reward_currency"
     {
-        "Order" "63"
+        "Order" "100"
         "TYPE" "dropdown"
         "DEFAULT" "red"
         "OPTIONS" {
@@ -216,14 +222,14 @@
 
     "roshan_kill_reward_amount"
     {
-        "Order" "64"
+        "Order" "101"
         "TYPE" "number"
         "DEFAULT" "200"
     }
     
     "lamp_capture_reward_currency"
     {
-        "Order" "73"
+        "Order" "110"
         "TYPE" "dropdown"
         "DEFAULT" "red"
         "OPTIONS" {
@@ -236,14 +242,14 @@
 
     "lamp_capture_reward_amount"
     {
-        "Order" "74"
+        "Order" "111"
         "TYPE" "number"
         "DEFAULT" "0"
     }
     
     "outpost_capture_reward_currency"
     {
-        "Order" "83"
+        "Order" "120"
         "TYPE" "dropdown"
         "DEFAULT" "red"
         "OPTIONS" {
@@ -256,7 +262,7 @@
 
     "outpost_capture_reward_amount"
     {
-        "Order" "84"
+        "Order" "121"
         "TYPE" "number"
         "DEFAULT" "10"
     }
@@ -264,7 +270,7 @@
 
     "tormentor_kill_reward_currency"
     {
-        "Order" "93"
+        "Order" "130"
         "TYPE" "dropdown"
         "DEFAULT" "red"
         "OPTIONS" {
@@ -277,7 +283,7 @@
 
     "tormentor_kill_reward_amount"
     {
-        "Order" "94"
+        "Order" "131"
         "TYPE" "number"
         "DEFAULT" "500"
     }
@@ -285,25 +291,25 @@
     //Starting amounts
     "red_start"
     {
-        "Order" "101"
+        "Order" "140"
         "TYPE" "number"
         "DEFAULT" "0"
     }
     "green_start"
     {
-        "Order" "102"
+        "Order" "141"
         "TYPE" "number"
         "DEFAULT" "0"
     }
     "blue_start"
     {
-        "Order" "103"
+        "Order" "142"
         "TYPE" "number"
         "DEFAULT" "0"
     }
     "purple_start"
     {
-        "Order" "104"
+        "Order" "143"
         "TYPE" "number"
         "DEFAULT" "0"
     }

--- a/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/currencies/settings.txt
+++ b/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/currencies/settings.txt
@@ -115,13 +115,13 @@
     {
         "Order" "53"
         "TYPE" "number"
-        "DEFAULT" "0"
+        "DEFAULT" "25"
     }
     "hero_kill_reward_bounty"
     {
         "Order" "54"
         "TYPE" "number"
-        "DEFAULT" "25"
+        "DEFAULT" "0"
     }
     
     "observer_kill_reward_currency"

--- a/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/dota_settings/plugin.lua
+++ b/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/dota_settings/plugin.lua
@@ -338,8 +338,8 @@ function DotaSettingsPlugin:ModifyGoldFilter(event)
     if event.gold == nil then
         print("[DotaSettingsPlugin] modify gold event is fucking up again.")
     end
-	event.gold = event.gold * DotaSettingsPlugin.settings.gold_gain_percent
-    return true
+	event.gold = event.gold * DotaSettingsPlugin.settings.gold_gain_percent * 0.01
+    return {true, event}
 end
 
     
@@ -347,8 +347,8 @@ function DotaSettingsPlugin:ModifyExperienceFilter(event)
     if event.experience == nil then
         print("[DotaSettingsPlugin] modify experience event is fucking up again.")
     end
-	event.experience = event.experience * DotaSettingsPlugin.settings.xp_gain_percent
-    return true
+	event.experience = event.experience * DotaSettingsPlugin.settings.xp_gain_percent * 0.01
+    return {true, event}
 end
 
 
@@ -372,5 +372,3 @@ function DotaSettingsPlugin:SpawnEvent(event)
         end
     end
 end
-
-

--- a/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/dota_settings/plugin.txt
+++ b/game/dota_addons/mgmod/scripts/vscripts/plugin_system/plugins/dota_settings/plugin.txt
@@ -7,5 +7,9 @@
             "ApplySettings" "DOTA_GAMERULES_STATE_HERO_SELECTION"
             "ApplySettingsStartGame" "DOTA_GAMERULES_STATE_GAME_IN_PROGRESS"
         }
+        "FilterRegistrations" {
+            "ModifyGoldFilter" "ModifyGoldFilter"
+            "ModifyExperienceFilter" "ModifyExperienceFilter"
+        }
     }
 }


### PR DESCRIPTION
This adds the option to make the hero kill currency reward be a percentage of the gold earned (thus handling things like streaks, first bloods, assist gold, etc.).